### PR TITLE
Add CRUD operations and frontend forms for expenses

### DIFF
--- a/src/main/java/arobu/glitterfinv2/controller/api/ExpenseEntryController.java
+++ b/src/main/java/arobu/glitterfinv2/controller/api/ExpenseEntryController.java
@@ -1,6 +1,6 @@
 package arobu.glitterfinv2.controller.api;
 
-import arobu.glitterfinv2.model.dto.ExpenseEntryPostDTO;
+import arobu.glitterfinv2.model.dto.ExpenseEntryCrudDTO;
 import arobu.glitterfinv2.model.entity.ExpenseEntry;
 import arobu.glitterfinv2.service.ExpenseEntryService;
 import arobu.glitterfinv2.service.exception.OwnerNotFoundException;
@@ -8,12 +8,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -28,20 +26,27 @@ public class ExpenseEntryController {
         this.expenseEntryService = expenseEntryService;
     }
 
+    @GetMapping
+    public List<ExpenseEntry> allExpenses() {
+        return expenseEntryService.getAllExpenses();
+    }
+
+    @GetMapping("/{id}")
+    public ExpenseEntryCrudDTO getExpense(@PathVariable Integer id) {
+        return expenseEntryService.getExpense(id);
+    }
+
     @PostMapping
-    public ResponseEntity<Map<String,String>> insertExpense(@RequestBody final ExpenseEntryPostDTO dto) {
+    public ResponseEntity<Map<String, String>> insertExpense(@RequestBody final ExpenseEntryCrudDTO dto) {
         Map<String, String> response = new HashMap<>();
         ExpenseEntry savedEntity;
         try {
             savedEntity = expenseEntryService.saveExpense(dto);
         } catch (OwnerNotFoundException e) {
-            LOGGER.error("Owner not found for expense {}",dto, e);
+            LOGGER.error("Owner not found for expense {}", dto, e);
             response.put("status", "failure");
             response.put("reason", "Owner not found for expense " + dto);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-            // vreau un un response code nasol
-            // Ce se intampla daca se arunca eroarea si o prind aici?
-            // mai e logata oare?
         }
 
         response.put("status", "success");
@@ -50,5 +55,17 @@ public class ExpenseEntryController {
         LOGGER.info(response.toString());
 
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}")
+    public ExpenseEntry updateExpense(@PathVariable Integer id, @RequestBody ExpenseEntryCrudDTO dto) throws OwnerNotFoundException {
+        dto.setId(id);
+        return expenseEntryService.saveExpense(dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteExpense(@PathVariable Integer id) {
+        expenseEntryService.deleteExpense(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/arobu/glitterfinv2/controller/frontend/ExpensesViewController.java
+++ b/src/main/java/arobu/glitterfinv2/controller/frontend/ExpensesViewController.java
@@ -1,11 +1,13 @@
 package arobu.glitterfinv2.controller.frontend;
 
+import arobu.glitterfinv2.model.dto.ExpenseEntryCrudDTO;
 import arobu.glitterfinv2.model.dto.ExpenseFrontendDTO;
 import arobu.glitterfinv2.service.ExpenseEntryService;
+import arobu.glitterfinv2.service.exception.OwnerNotFoundException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,5 +30,37 @@ public class ExpensesViewController {
         model.addAttribute("username", username);
 
         return "expenses";
+    }
+
+    @GetMapping("/expenses/new")
+    public String newExpense(Model model) {
+        model.addAttribute("expense", new ExpenseEntryCrudDTO());
+        return "expense-form";
+    }
+
+
+    @GetMapping("/expenses/{id}/edit")
+    public String editExpense(@PathVariable Integer id, Model model) {
+        model.addAttribute("expense", expenseEntryService.getExpense(id));
+        return "expense-form";
+    }
+
+    @PostMapping("/expenses")
+    public String createExpense(@ModelAttribute ExpenseEntryCrudDTO expense) throws OwnerNotFoundException {
+        expenseEntryService.saveExpense(expense);
+        return "redirect:/expenses";
+    }
+
+    @PostMapping("/expenses/{id}")
+    public String updateExpense(@PathVariable Integer id, @ModelAttribute ExpenseEntryCrudDTO expense) throws OwnerNotFoundException {
+        expense.setId(id);
+        expenseEntryService.saveExpense(expense);
+        return "redirect:/expenses";
+    }
+
+    @PostMapping("/expenses/{id}/delete")
+    public String deleteExpense(@PathVariable Integer id) {
+        expenseEntryService.deleteExpense(id);
+        return "redirect:/expenses";
     }
 }

--- a/src/main/java/arobu/glitterfinv2/controller/frontend/MvcConfig.java
+++ b/src/main/java/arobu/glitterfinv2/controller/frontend/MvcConfig.java
@@ -10,6 +10,5 @@ public class MvcConfig implements WebMvcConfigurer {
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addViewController("/").setViewName("index");
         registry.addViewController("/login").setViewName("login");
-        registry.addViewController("/expenses").setViewName("expenses");
     }
 }

--- a/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryCrudDTO.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryCrudDTO.java
@@ -1,0 +1,84 @@
+package arobu.glitterfinv2.model.dto;
+
+public class ExpenseEntryCrudDTO {
+    private Integer id;
+    private Double amount;
+    private String timestamp;
+    private String source;
+    private String merchant;
+    private String category;
+    private String latitude;
+    private String longitude;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public ExpenseEntryCrudDTO setId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public ExpenseEntryCrudDTO setAmount(Double amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public ExpenseEntryCrudDTO setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public ExpenseEntryCrudDTO setSource(String source) {
+        this.source = source;
+        return this;
+    }
+
+    public String getMerchant() {
+        return merchant;
+    }
+
+    public ExpenseEntryCrudDTO setMerchant(String merchant) {
+        this.merchant = merchant;
+        return this;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public ExpenseEntryCrudDTO setCategory(String category) {
+        this.category = category;
+        return this;
+    }
+
+    public String getLatitude() {
+        return latitude;
+    }
+
+    public ExpenseEntryCrudDTO setLatitude(String latitude) {
+        this.latitude = latitude;
+        return this;
+    }
+
+    public String getLongitude() {
+        return longitude;
+    }
+
+    public ExpenseEntryCrudDTO setLongitude(String longitude) {
+        this.longitude = longitude;
+        return this;
+    }
+}

--- a/src/main/java/arobu/glitterfinv2/model/dto/ExpenseFrontendDTO.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/ExpenseFrontendDTO.java
@@ -3,6 +3,7 @@ package arobu.glitterfinv2.model.dto;
 import java.time.ZonedDateTime;
 
 public class ExpenseFrontendDTO {
+    private Integer id;
     private Double amount;
     private ZonedDateTime timestamp;
     private String merchant;
@@ -11,6 +12,15 @@ public class ExpenseFrontendDTO {
     private String category;
 
     public ExpenseFrontendDTO() {
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public ExpenseFrontendDTO setId(Integer id) {
+        this.id = id;
+        return this;
     }
 
     public Double getAmount() {

--- a/src/main/java/arobu/glitterfinv2/model/dto/LocationData.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/LocationData.java
@@ -11,4 +11,14 @@ public class LocationData {
     public String getLongitude() {
         return longitude;
     }
+
+    public LocationData setLatitude(String latitude) {
+        this.latitude = latitude;
+        return this;
+    }
+
+    public LocationData setLongitude(String longitude) {
+        this.longitude = longitude;
+        return this;
+    }
 }

--- a/src/main/java/arobu/glitterfinv2/service/mapper/ExpenseEntryMapper.java
+++ b/src/main/java/arobu/glitterfinv2/service/mapper/ExpenseEntryMapper.java
@@ -45,6 +45,7 @@ public class ExpenseEntryMapper {
         ExpenseFrontendDTO expenseFrontendDTO = new ExpenseFrontendDTO();
 
         return expenseFrontendDTO
+                .setId(expense.getId())
                 .setAmount(expense.getAmount())
                 .setCategory(expense.getCategory())
                 .setLocation(expense.getLocation().getDisplayName())

--- a/src/main/resources/templates/expense-form.html
+++ b/src/main/resources/templates/expense-form.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${expense.id} != null ? 'Edit Expense' : 'Add Expense'">Expense</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body>
+<div th:insert="~{fragments/header :: header}"></div>
+<main>
+    <div class="container">
+        <h1 th:text="${expense.id} != null ? 'Edit Expense' : 'Add Expense'">Expense</h1>
+        <form th:action="@{${expense.id} != null ? '/expenses/' + ${expense.id} : '/expenses'}" th:object="${expense}" method="post">
+            <input type="hidden" th:field="*{id}" th:if="${expense.id}" />
+            <label>Amount</label>
+            <input type="number" step="0.01" th:field="*{amount}" />
+            <label>Timestamp</label>
+            <input type="text" th:field="*{timestamp}" />
+            <label>Source</label>
+            <input type="text" th:field="*{source}" />
+            <label>Merchant</label>
+            <input type="text" th:field="*{merchant}" />
+            <label>Category</label>
+            <input type="text" th:field="*{category}" />
+            <label>Latitude</label>
+            <input type="text" th:field="*{latitude}" />
+            <label>Longitude</label>
+            <input type="text" th:field="*{longitude}" />
+            <button type="submit">Save</button>
+        </form>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/expenses.html
+++ b/src/main/resources/templates/expenses.html
@@ -15,6 +15,7 @@
             <h2>These are <span th:text="${username}">user</span>'s expenses</h2>
         </div>
 
+        <a href="/expenses/new">Add Expense</a>
 
         <table th:if="${expenses}">
             <thead>
@@ -24,6 +25,7 @@
                 <th>Merchant</th>
                 <th>Location</th>
                 <th>Category</th>
+                <th>Actions</th>
             </tr>
             </thead>
             <tbody>
@@ -33,6 +35,12 @@
                 <td th:text="${expense.merchant}">Merchant</td>
                 <td th:text="${expense.location}">Location</td>
                 <td th:text="${expense.category}">Category</td>
+                <td>
+                    <a th:href="@{'/expenses/' + ${expense.id} + '/edit'}">Edit</a>
+                    <form th:action="@{'/expenses/' + ${expense.id} + '/delete'}" method="post" style="display:inline">
+                        <button type="submit">Delete</button>
+                    </form>
+                </td>
             </tr>
             </tbody>
         </table>


### PR DESCRIPTION
## Summary
- Implement CRUD DTO and service methods for expenses
- Expose REST endpoints for listing, updating and deleting expenses
- Add Thymeleaf views to create, edit and remove expenses from the UI

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for arobu:glitterfin-v2:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f729cad88328821bf4c557f8b33d