### PR TITLE
Add CRUD support for expenses

### DIFF
--- a/src/main/java/arobu/glitterfinv2/controller/api/ExpenseEntryController.java
+++ b/src/main/java/arobu/glitterfinv2/controller/api/ExpenseEntryController.java
@@ -1,19 +1,20 @@
 package arobu.glitterfinv2.controller.api;
 
 import arobu.glitterfinv2.model.dto.ExpenseEntryPostDTO;
+import arobu.glitterfinv2.model.dto.ExpenseFrontendDTO;
 import arobu.glitterfinv2.model.entity.ExpenseEntry;
 import arobu.glitterfinv2.service.ExpenseEntryService;
+import arobu.glitterfinv2.service.exception.ExpenseNotFoundException;
 import arobu.glitterfinv2.service.exception.OwnerNotFoundException;
+import arobu.glitterfinv2.service.mapper.ExpenseEntryMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -28,20 +29,32 @@ public class ExpenseEntryController {
         this.expenseEntryService = expenseEntryService;
     }
 
+    @GetMapping
+    public List<ExpenseFrontendDTO> getExpenses() {
+        return expenseEntryService.getExpensesForCurrentUser();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ExpenseFrontendDTO> getExpense(@PathVariable Integer id) {
+        try {
+            ExpenseEntry expense = expenseEntryService.getExpenseById(id);
+            return ResponseEntity.ok(ExpenseEntryMapper.toFrontend(expense));
+        } catch (ExpenseNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+    }
+
     @PostMapping
-    public ResponseEntity<Map<String,String>> insertExpense(@RequestBody final ExpenseEntryPostDTO dto) {
+    public ResponseEntity<Map<String, String>> insertExpense(@RequestBody final ExpenseEntryPostDTO dto) {
         Map<String, String> response = new HashMap<>();
         ExpenseEntry savedEntity;
         try {
             savedEntity = expenseEntryService.saveExpense(dto);
         } catch (OwnerNotFoundException e) {
-            LOGGER.error("Owner not found for expense {}",dto, e);
+            LOGGER.error("Owner not found for expense {}", dto, e);
             response.put("status", "failure");
             response.put("reason", "Owner not found for expense " + dto);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-            // vreau un un response code nasol
-            // Ce se intampla daca se arunca eroarea si o prind aici?
-            // mai e logata oare?
         }
 
         response.put("status", "success");
@@ -50,5 +63,41 @@ public class ExpenseEntryController {
         LOGGER.info(response.toString());
 
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Map<String, String>> updateExpense(@PathVariable Integer id, @RequestBody ExpenseEntryPostDTO dto) {
+        Map<String, String> response = new HashMap<>();
+        try {
+            ExpenseEntry updated = expenseEntryService.updateExpense(id, dto);
+            response.put("status", "success");
+            response.put("expense", updated.toString());
+            return ResponseEntity.ok(response);
+        } catch (OwnerNotFoundException e) {
+            LOGGER.error("Owner not found for expense {}", dto, e);
+            response.put("status", "failure");
+            response.put("reason", "Owner not found for expense " + dto);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        } catch (ExpenseNotFoundException e) {
+            LOGGER.error("Expense not found: {}", id, e);
+            response.put("status", "failure");
+            response.put("reason", e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Map<String, String>> deleteExpense(@PathVariable Integer id) {
+        Map<String, String> response = new HashMap<>();
+        try {
+            expenseEntryService.deleteExpense(id);
+            response.put("status", "success");
+            return ResponseEntity.ok(response);
+        } catch (ExpenseNotFoundException e) {
+            LOGGER.error("Expense not found: {}", id, e);
+            response.put("status", "failure");
+            response.put("reason", e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+        }
     }
 }

--- a/src/main/java/arobu/glitterfinv2/controller/frontend/ExpensesViewController.java
+++ b/src/main/java/arobu/glitterfinv2/controller/frontend/ExpensesViewController.java
@@ -1,11 +1,16 @@
 package arobu.glitterfinv2.controller.frontend;
 
+import arobu.glitterfinv2.model.dto.ExpenseEntryPostDTO;
 import arobu.glitterfinv2.model.dto.ExpenseFrontendDTO;
+import arobu.glitterfinv2.model.entity.ExpenseEntry;
 import arobu.glitterfinv2.service.ExpenseEntryService;
+import arobu.glitterfinv2.service.exception.ExpenseNotFoundException;
+import arobu.glitterfinv2.service.exception.OwnerNotFoundException;
+import arobu.glitterfinv2.service.mapper.ExpenseEntryMapper;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,5 +33,40 @@ public class ExpensesViewController {
         model.addAttribute("username", username);
 
         return "expenses";
+    }
+
+    @GetMapping("/expenses/new")
+    public String showCreateForm(Model model) {
+        model.addAttribute("expense", new ExpenseEntryPostDTO());
+        model.addAttribute("appName", "Glitterfin v2");
+        return "expense-form";
+    }
+
+    @PostMapping("/expenses")
+    public String createExpense(@ModelAttribute ExpenseEntryPostDTO expenseEntryPostDTO) throws OwnerNotFoundException {
+        expenseEntryService.saveExpense(expenseEntryPostDTO);
+        return "redirect:/expenses";
+    }
+
+    @GetMapping("/expenses/edit/{id}")
+    public String showEditForm(@PathVariable Integer id, Model model) throws ExpenseNotFoundException {
+        ExpenseEntry expense = expenseEntryService.getExpenseById(id);
+        ExpenseEntryPostDTO dto = ExpenseEntryMapper.toPostDto(expense);
+        model.addAttribute("expense", dto);
+        model.addAttribute("expenseId", id);
+        model.addAttribute("appName", "Glitterfin v2");
+        return "expense-form";
+    }
+
+    @PostMapping("/expenses/{id}")
+    public String updateExpense(@PathVariable Integer id, @ModelAttribute ExpenseEntryPostDTO expenseEntryPostDTO) throws OwnerNotFoundException, ExpenseNotFoundException {
+        expenseEntryService.updateExpense(id, expenseEntryPostDTO);
+        return "redirect:/expenses";
+    }
+
+    @PostMapping("/expenses/{id}/delete")
+    public String deleteExpense(@PathVariable Integer id) throws ExpenseNotFoundException {
+        expenseEntryService.deleteExpense(id);
+        return "redirect:/expenses";
     }
 }

--- a/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryPostDTO.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryPostDTO.java
@@ -58,4 +58,39 @@ public class ExpenseEntryPostDTO {
         this.outlier = outlier;
         return this;
     }
+
+    public ExpenseEntryPostDTO setAmount(Double amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public ExpenseEntryPostDTO setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    public ExpenseEntryPostDTO setSource(String source) {
+        this.source = source;
+        return this;
+    }
+
+    public ExpenseEntryPostDTO setMerchant(String merchant) {
+        this.merchant = merchant;
+        return this;
+    }
+
+    public ExpenseEntryPostDTO setLocationData(LocationData locationData) {
+        this.locationData = locationData;
+        return this;
+    }
+
+    public ExpenseEntryPostDTO setCategory(String category) {
+        this.category = category;
+        return this;
+    }
+
+    public ExpenseEntryPostDTO setReceiptData(String receiptData) {
+        this.receiptData = receiptData;
+        return this;
+    }
 }

--- a/src/main/java/arobu/glitterfinv2/model/dto/ExpenseFrontendDTO.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/ExpenseFrontendDTO.java
@@ -3,6 +3,7 @@ package arobu.glitterfinv2.model.dto;
 import java.time.ZonedDateTime;
 
 public class ExpenseFrontendDTO {
+    private Integer id;
     private Double amount;
     private ZonedDateTime timestamp;
     private String merchant;
@@ -11,6 +12,10 @@ public class ExpenseFrontendDTO {
     private String category;
 
     public ExpenseFrontendDTO() {
+    }
+
+    public Integer getId() {
+        return id;
     }
 
     public Double getAmount() {
@@ -31,6 +36,11 @@ public class ExpenseFrontendDTO {
 
     public String getCategory() {
         return category;
+    }
+
+    public ExpenseFrontendDTO setId(Integer id) {
+        this.id = id;
+        return this;
     }
 
     public ExpenseFrontendDTO setAmount(Double amount) {
@@ -60,7 +70,8 @@ public class ExpenseFrontendDTO {
 
     @Override
     public String toString() {
-        return  "amount=" + amount +
+        return  "id=" + id +
+                ", amount=" + amount +
                 ", timestamp='" + timestamp + '\'' +
                 ", merchant='" + merchant + '\'' +
                 ", location='" + location + '\'' +

--- a/src/main/java/arobu/glitterfinv2/model/dto/LocationData.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/LocationData.java
@@ -11,4 +11,14 @@ public class LocationData {
     public String getLongitude() {
         return longitude;
     }
+
+    public LocationData setLatitude(String latitude) {
+        this.latitude = latitude;
+        return this;
+    }
+
+    public LocationData setLongitude(String longitude) {
+        this.longitude = longitude;
+        return this;
+    }
 }

--- a/src/main/java/arobu/glitterfinv2/service/exception/ExpenseNotFoundException.java
+++ b/src/main/java/arobu/glitterfinv2/service/exception/ExpenseNotFoundException.java
@@ -1,0 +1,7 @@
+package arobu.glitterfinv2.service.exception;
+
+public class ExpenseNotFoundException extends Exception {
+    public ExpenseNotFoundException(Integer id) {
+        super("Expense with id " + id + " not found");
+    }
+}

--- a/src/main/java/arobu/glitterfinv2/service/mapper/ExpenseEntryMapper.java
+++ b/src/main/java/arobu/glitterfinv2/service/mapper/ExpenseEntryMapper.java
@@ -2,6 +2,7 @@ package arobu.glitterfinv2.service.mapper;
 
 import arobu.glitterfinv2.model.dto.ExpenseEntryPostDTO;
 import arobu.glitterfinv2.model.dto.ExpenseFrontendDTO;
+import arobu.glitterfinv2.model.dto.LocationData;
 import arobu.glitterfinv2.model.entity.ExpenseEntry;
 import arobu.glitterfinv2.model.entity.ExpenseOwner;
 import arobu.glitterfinv2.model.entity.Location;
@@ -45,11 +46,29 @@ public class ExpenseEntryMapper {
         ExpenseFrontendDTO expenseFrontendDTO = new ExpenseFrontendDTO();
 
         return expenseFrontendDTO
+                .setId(expense.getId())
                 .setAmount(expense.getAmount())
                 .setCategory(expense.getCategory())
                 .setLocation(expense.getLocation().getDisplayName())
                 .setMerchant(expense.getMerchant())
                 .setTimestamp(expense.getTimestamp());
+    }
+
+    public static ExpenseEntryPostDTO toPostDto(ExpenseEntry expense) {
+        LocationData locationData = new LocationData()
+                .setLatitude(expense.getLocation().getLatitude().toString())
+                .setLongitude(expense.getLocation().getLongitude().toString());
+
+        return new ExpenseEntryPostDTO()
+                .setAmount(expense.getAmount())
+                .setTimestamp(expense.getTimestamp().toString())
+                .setSource(expense.getSource())
+                .setMerchant(expense.getMerchant())
+                .setLocationData(locationData)
+                .setCategory(expense.getCategory())
+                .setReceiptData(expense.getReceiptData())
+                .setShared(expense.getShared())
+                .setOutlier(expense.getOutlier());
     }
 
     private String extractMerchant(final ExpenseEntryPostDTO dto) {

--- a/src/main/resources/templates/expense-form.html
+++ b/src/main/resources/templates/expense-form.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${appName}">Glitterfin</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body>
+<div th:insert="~{fragments/header :: header}"></div>
+<main>
+    <div class="container">
+        <h1 th:text="${expenseId} == null ? 'New Expense' : 'Edit Expense'"></h1>
+        <form th:action="${expenseId} == null ? '/expenses' : '/expenses/' + expenseId" th:object="${expense}" method="post">
+            <label>Amount: <input type="text" th:field="*{amount}"/></label><br/>
+            <label>Timestamp: <input type="text" th:field="*{timestamp}"/></label><br/>
+            <label>Source: <input type="text" th:field="*{source}"/></label><br/>
+            <label>Merchant: <input type="text" th:field="*{merchant}"/></label><br/>
+            <label>Category: <input type="text" th:field="*{category}"/></label><br/>
+            <label>Latitude: <input type="text" th:field="*{locationData.latitude}"/></label><br/>
+            <label>Longitude: <input type="text" th:field="*{locationData.longitude}"/></label><br/>
+            <label>Shared: <input type="checkbox" th:field="*{shared}"/></label><br/>
+            <label>Outlier: <input type="checkbox" th:field="*{outlier}"/></label><br/>
+            <button type="submit">Save</button>
+        </form>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/expenses.html
+++ b/src/main/resources/templates/expenses.html
@@ -14,7 +14,9 @@
         <div th:if="${username}" class="user-info">
             <h2>These are <span th:text="${username}">user</span>'s expenses</h2>
         </div>
-
+        <div class="actions">
+            <a href="/expenses/new">Add Expense</a>
+        </div>
 
         <table th:if="${expenses}">
             <thead>
@@ -24,6 +26,7 @@
                 <th>Merchant</th>
                 <th>Location</th>
                 <th>Category</th>
+                <th>Actions</th>
             </tr>
             </thead>
             <tbody>
@@ -33,6 +36,12 @@
                 <td th:text="${expense.merchant}">Merchant</td>
                 <td th:text="${expense.location}">Location</td>
                 <td th:text="${expense.category}">Category</td>
+                <td>
+                    <a th:href="@{/expenses/edit/{id}(id=${expense.id})}">Edit</a>
+                    <form th:action="@{/expenses/{id}/delete(id=${expense.id})}" method="post" style="display:inline">
+                        <button type="submit">Delete</button>
+                    </form>
+                </td>
             </tr>
             </tbody>
         </table>


### PR DESCRIPTION
## Summary
- add REST endpoints for retrieving, updating and deleting expenses
- expose create/edit/delete expense flows in the frontend
- extend DTOs and mappers to carry ids and handle form binding

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f729cad88328821bf4c557f8b33d