### PR TITLE
Add ExpenseEntry web CRUD pages and DTO

### DIFF
--- a/src/main/java/arobu/glitterfinv2/controller/frontend/ExpenseEntryController.java
+++ b/src/main/java/arobu/glitterfinv2/controller/frontend/ExpenseEntryController.java
@@ -1,0 +1,81 @@
+package arobu.glitterfinv2.controller.frontend;
+
+import arobu.glitterfinv2.model.dto.ExpenseEntryPostDTO;
+import arobu.glitterfinv2.model.dto.ExpenseEntryQuickShowDTO;
+import arobu.glitterfinv2.model.dto.LocationData;
+import arobu.glitterfinv2.model.entity.ExpenseEntry;
+import arobu.glitterfinv2.service.ExpenseEntryService;
+import arobu.glitterfinv2.service.exception.OwnerNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * MVC controller exposing a simple web interface for managing expense entries.
+ */
+@Controller
+@RequestMapping("/expenses")
+public class ExpenseEntryController {
+
+    private final ExpenseEntryService expenseEntryService;
+
+    public ExpenseEntryController(ExpenseEntryService expenseEntryService) {
+        this.expenseEntryService = expenseEntryService;
+    }
+
+    @GetMapping
+    public String listExpenses(Model model, Authentication authentication) {
+        List<ExpenseEntryQuickShowDTO> expenses =
+                expenseEntryService.getExpensesForUser(authentication.getName());
+        model.addAttribute("expenses", expenses);
+        model.addAttribute("expense", new ExpenseEntryPostDTO());
+        return "expenses";
+    }
+
+    @PostMapping
+    public String createExpense(@ModelAttribute("expense") ExpenseEntryPostDTO dto,
+                                Authentication authentication) throws OwnerNotFoundException {
+        expenseEntryService.saveExpense(dto, authentication.getName());
+        return "redirect:/expenses";
+    }
+
+    @GetMapping("/{id}")
+    public String editExpense(@PathVariable Integer id, Model model) {
+        ExpenseEntry entry = expenseEntryService.getExpense(id);
+        if (entry == null) {
+            return "redirect:/expenses";
+        }
+        ExpenseEntryPostDTO dto = new ExpenseEntryPostDTO()
+                .setAmount(entry.getAmount())
+                .setTimestamp(entry.getTimestamp().toString())
+                .setSource(entry.getSource())
+                .setMerchant(entry.getMerchant());
+        if (entry.getLocation() != null) {
+            LocationData ld = new LocationData()
+                    .setLatitude(String.valueOf(entry.getLocation().getLatitude()))
+                    .setLongitude(String.valueOf(entry.getLocation().getLongitude()));
+            dto.setLocationData(ld);
+        }
+        model.addAttribute("expense", dto);
+        model.addAttribute("expenseId", id);
+        return "expense-edit";
+    }
+
+    @PostMapping("/{id}")
+    public String updateExpense(@PathVariable Integer id,
+                                @ModelAttribute("expense") ExpenseEntryPostDTO dto,
+                                Authentication authentication) throws OwnerNotFoundException {
+        expenseEntryService.updateExpense(id, dto, authentication.getName());
+        return "redirect:/expenses";
+    }
+
+    @PostMapping("/{id}/delete")
+    public String deleteExpense(@PathVariable Integer id) {
+        expenseEntryService.deleteExpense(id);
+        return "redirect:/expenses";
+    }
+}
+

--- a/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryPostDTO.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryPostDTO.java
@@ -6,7 +6,7 @@ public class ExpenseEntryPostDTO {
     private String source;
     private String merchant;
 
-    private LocationData locationData;
+    private LocationData locationData = new LocationData();
     private String category;
     private String receiptData;
 
@@ -17,28 +17,63 @@ public class ExpenseEntryPostDTO {
         return amount;
     }
 
+    public ExpenseEntryPostDTO setAmount(Double amount) {
+        this.amount = amount;
+        return this;
+    }
+
     public String getTimestamp() {
         return timestamp;
+    }
+
+    public ExpenseEntryPostDTO setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+        return this;
     }
 
     public String getSource() {
         return source;
     }
 
+    public ExpenseEntryPostDTO setSource(String source) {
+        this.source = source;
+        return this;
+    }
+
     public String getMerchant() {
         return merchant;
+    }
+
+    public ExpenseEntryPostDTO setMerchant(String merchant) {
+        this.merchant = merchant;
+        return this;
     }
 
     public LocationData getLocationData() {
         return locationData;
     }
 
+    public ExpenseEntryPostDTO setLocationData(LocationData locationData) {
+        this.locationData = locationData;
+        return this;
+    }
+
     public String getCategory() {
         return category;
     }
 
+    public ExpenseEntryPostDTO setCategory(String category) {
+        this.category = category;
+        return this;
+    }
+
     public String getReceiptData() {
         return receiptData;
+    }
+
+    public ExpenseEntryPostDTO setReceiptData(String receiptData) {
+        this.receiptData = receiptData;
+        return this;
     }
 
     public Boolean getShared() {

--- a/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryQuickShowDTO.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryQuickShowDTO.java
@@ -1,5 +1,63 @@
 package arobu.glitterfinv2.model.dto;
 
+import java.time.ZonedDateTime;
+
+/**
+ * DTO used for displaying expense entries on the UI. Only exposes the
+ * amount, timestamp, merchant and location fields along with the id for
+ * further operations.
+ */
 public class ExpenseEntryQuickShowDTO {
 
+    private Integer id;
+    private Double amount;
+    private ZonedDateTime timestamp;
+    private String merchant;
+    private String location;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public ExpenseEntryQuickShowDTO setId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public ExpenseEntryQuickShowDTO setAmount(Double amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public ExpenseEntryQuickShowDTO setTimestamp(ZonedDateTime timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    public String getMerchant() {
+        return merchant;
+    }
+
+    public ExpenseEntryQuickShowDTO setMerchant(String merchant) {
+        this.merchant = merchant;
+        return this;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public ExpenseEntryQuickShowDTO setLocation(String location) {
+        this.location = location;
+        return this;
+    }
 }
+

--- a/src/main/java/arobu/glitterfinv2/model/dto/LocationData.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/LocationData.java
@@ -11,4 +11,14 @@ public class LocationData {
     public String getLongitude() {
         return longitude;
     }
+
+    public LocationData setLatitude(String latitude) {
+        this.latitude = latitude;
+        return this;
+    }
+
+    public LocationData setLongitude(String longitude) {
+        this.longitude = longitude;
+        return this;
+    }
 }

--- a/src/main/java/arobu/glitterfinv2/model/mapper/ExpenseEntryMapper.java
+++ b/src/main/java/arobu/glitterfinv2/model/mapper/ExpenseEntryMapper.java
@@ -1,6 +1,7 @@
 package arobu.glitterfinv2.model.mapper;
 
 import arobu.glitterfinv2.model.dto.ExpenseEntryPostDTO;
+import arobu.glitterfinv2.model.dto.ExpenseEntryQuickShowDTO;
 import arobu.glitterfinv2.model.entity.ExpenseEntry;
 import arobu.glitterfinv2.model.entity.ExpenseOwner;
 import arobu.glitterfinv2.model.entity.Location;
@@ -38,6 +39,15 @@ public class ExpenseEntryMapper {
         }
 
         return expense;
+    }
+
+    public static ExpenseEntryQuickShowDTO toQuickShowDTO(final ExpenseEntry entity) {
+        return new ExpenseEntryQuickShowDTO()
+                .setId(entity.getId())
+                .setAmount(entity.getAmount())
+                .setTimestamp(entity.getTimestamp())
+                .setMerchant(entity.getMerchant())
+                .setLocation(entity.getLocation() != null ? entity.getLocation().getDisplayName() : null);
     }
 
     private String extractMerchant(final ExpenseEntryPostDTO dto) {

--- a/src/main/java/arobu/glitterfinv2/service/ExpenseEntryService.java
+++ b/src/main/java/arobu/glitterfinv2/service/ExpenseEntryService.java
@@ -1,6 +1,7 @@
 package arobu.glitterfinv2.service;
 
 import arobu.glitterfinv2.model.dto.ExpenseEntryPostDTO;
+import arobu.glitterfinv2.model.dto.ExpenseEntryQuickShowDTO;
 import arobu.glitterfinv2.model.entity.ExpenseEntry;
 import arobu.glitterfinv2.model.entity.ExpenseOwner;
 import arobu.glitterfinv2.model.entity.Location;
@@ -10,6 +11,10 @@ import arobu.glitterfinv2.service.exception.OwnerNotFoundException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ExpenseEntryService {
@@ -33,5 +38,47 @@ public class ExpenseEntryService {
         ExpenseEntry entity = ExpenseEntryMapper.toEntity(expenseEntryPostDTO, owner, location);
         LOGGER.info("Persisting expense entry: {}", entity);
         return expenseEntryRepository.save(entity);
+    }
+
+    public List<ExpenseEntryQuickShowDTO> getExpensesForUser(final String username) {
+        return expenseEntryRepository.findAllByOwner_Username(username)
+                .stream()
+                .map(ExpenseEntryMapper::toQuickShowDTO)
+                .collect(Collectors.toList());
+    }
+
+    public ExpenseEntry getExpense(final Integer id) {
+        return expenseEntryRepository.findById(id).orElse(null);
+    }
+
+    public ExpenseEntry updateExpense(final Integer id, final ExpenseEntryPostDTO dto, final String username) throws OwnerNotFoundException {
+        ExpenseEntry existing = getExpense(id);
+        if (existing == null) {
+            return null;
+        }
+        ExpenseOwner owner = expenseOwnerService.getExpenseOwnerEntityByUsername(username);
+        Location location = locationService.getOrSaveLocationEntity(dto.getLocationData());
+
+        existing.setOwner(owner)
+                .setAmount(dto.getAmount())
+                .setTimestamp(ZonedDateTime.parse(dto.getTimestamp()))
+                .setTimezone(ZonedDateTime.parse(dto.getTimestamp()).getZone().getId())
+                .setSource(dto.getSource())
+                .setMerchant(dto.getMerchant())
+                .setLocation(location)
+                .setReceiptData(dto.getReceiptData());
+
+        if (dto.getShared() != null) {
+            existing.setShared(dto.getShared());
+        }
+        if (dto.getOutlier() != null) {
+            existing.setOutlier(dto.getOutlier());
+        }
+        LOGGER.info("Updating expense entry: {}", existing);
+        return expenseEntryRepository.save(existing);
+    }
+
+    public void deleteExpense(final Integer id) {
+        expenseEntryRepository.deleteById(id);
     }
 }

--- a/src/main/resources/templates/expense-edit.html
+++ b/src/main/resources/templates/expense-edit.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Edit Expense</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body>
+<main>
+    <div class="container">
+        <h2>Edit Expense</h2>
+        <form th:action="@{'/expenses/' + ${expenseId}}" th:object="${expense}" method="post">
+            <input type="number" step="0.01" th:field="*{amount}" placeholder="Amount" required/>
+            <input type="text" th:field="*{timestamp}" placeholder="Timestamp" required/>
+            <input type="text" th:field="*{merchant}" placeholder="Merchant" required/>
+            <input type="text" th:field="*{locationData.latitude}" placeholder="Latitude" required/>
+            <input type="text" th:field="*{locationData.longitude}" placeholder="Longitude" required/>
+            <button type="submit">Save</button>
+        </form>
+        <a th:href="@{/expenses}">Back</a>
+    </div>
+</main>
+</body>
+</html>
+

--- a/src/main/resources/templates/expenses.html
+++ b/src/main/resources/templates/expenses.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Expenses</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body>
+<main>
+    <div class="container">
+        <h2>Your Expenses</h2>
+
+        <form th:action="@{/expenses}" th:object="${expense}" method="post">
+            <input type="number" step="0.01" th:field="*{amount}" placeholder="Amount" required/>
+            <input type="text" th:field="*{timestamp}" placeholder="Timestamp" required/>
+            <input type="text" th:field="*{merchant}" placeholder="Merchant" required/>
+            <input type="text" th:field="*{locationData.latitude}" placeholder="Latitude" required/>
+            <input type="text" th:field="*{locationData.longitude}" placeholder="Longitude" required/>
+            <button type="submit">Add</button>
+        </form>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Amount</th>
+                <th>Timestamp</th>
+                <th>Merchant</th>
+                <th>Location</th>
+                <th>Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="exp : ${expenses}">
+                <td th:text="${exp.amount}"></td>
+                <td th:text="${exp.timestamp}"></td>
+                <td th:text="${exp.merchant}"></td>
+                <td th:text="${exp.location}"></td>
+                <td>
+                    <a th:href="@{'/expenses/' + ${exp.id}}">Edit</a>
+                    <form th:action="@{'/expenses/' + ${exp.id} + '/delete'}" method="post" style="display:inline">
+                        <button type="submit">Delete</button>
+                    </form>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</main>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- introduce `ExpenseEntryQuickShowDTO` with amount, timestamp, merchant and location for UI display
- add service, controller and Thymeleaf pages to perform CRUD operations on expenses
- expose web forms for creating, editing and deleting expenses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM – network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68c42640c7708328a98d0f7db2d6c1d0