### PR TITLE
Add expense dashboard and refresh frontend styling

### DIFF
--- a/src/main/java/arobu/glitterfinv2/controller/frontend/ExpenseDashboardController.java
+++ b/src/main/java/arobu/glitterfinv2/controller/frontend/ExpenseDashboardController.java
@@ -1,0 +1,145 @@
+package arobu.glitterfinv2.controller.frontend;
+
+import arobu.glitterfinv2.model.dto.ExpenseEntryForm;
+import arobu.glitterfinv2.model.entity.ExpenseEntry;
+import arobu.glitterfinv2.service.ExpenseEntryService;
+import arobu.glitterfinv2.service.exception.ExpenseNotFoundException;
+import jakarta.validation.Valid;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Controller
+@RequestMapping("/expenses")
+public class ExpenseDashboardController {
+
+    private final ExpenseEntryService expenseEntryService;
+
+    public ExpenseDashboardController(ExpenseEntryService expenseEntryService) {
+        this.expenseEntryService = expenseEntryService;
+    }
+
+    @GetMapping
+    public String listExpenses(Model model) {
+        Optional<String> username = currentUsername();
+        List<ExpenseEntry> expenses = username
+                .map(expenseEntryService::getExpensesForUser)
+                .orElse(Collections.emptyList());
+
+        populateBaseModel(model, expenses);
+        model.addAttribute("expenseForm", new ExpenseEntryForm());
+        return "expenses/list";
+    }
+
+    @GetMapping("/{expenseId}/edit")
+    public String editExpense(@PathVariable Integer expenseId, Model model, RedirectAttributes redirectAttributes) {
+        Optional<String> username = currentUsername();
+        if (username.isEmpty()) {
+            return "redirect:/login";
+        }
+
+        ExpenseEntry expense;
+        try {
+            expense = expenseEntryService.getExpenseForUser(username.get(), expenseId);
+        } catch (ExpenseNotFoundException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "We could not find that expense.");
+            return "redirect:/expenses";
+        }
+
+        List<ExpenseEntry> expenses = expenseEntryService.getExpensesForUser(username.get());
+        populateBaseModel(model, expenses);
+        model.addAttribute("expenseForm", ExpenseEntryForm.fromEntity(expense));
+        model.addAttribute("editing", true);
+        model.addAttribute("editExpenseId", expenseId);
+        return "expenses/list";
+    }
+
+    @PostMapping("/{expenseId}/edit")
+    public String updateExpense(@PathVariable Integer expenseId,
+                                @Valid @ModelAttribute("expenseForm") ExpenseEntryForm expenseForm,
+                                BindingResult bindingResult,
+                                Model model,
+                                RedirectAttributes redirectAttributes) {
+        Optional<String> username = currentUsername();
+        if (username.isEmpty()) {
+            return "redirect:/login";
+        }
+
+        if (bindingResult.hasErrors()) {
+            List<ExpenseEntry> expenses = expenseEntryService.getExpensesForUser(username.get());
+            populateBaseModel(model, expenses);
+            model.addAttribute("editing", true);
+            model.addAttribute("editExpenseId", expenseId);
+            return "expenses/list";
+        }
+
+        try {
+            expenseEntryService.updateExpenseForUser(username.get(), expenseId, expense -> {
+                expense.setAmount(expenseForm.getAmount());
+                expense.setCategory(expenseForm.getCategory());
+                expense.setMerchant(expenseForm.getMerchant());
+                expense.setDescription(expenseForm.getDescription());
+                expense.setSource(expenseForm.getSource());
+                expense.setShared(Boolean.TRUE.equals(expenseForm.getShared()));
+                expense.setOutlier(Boolean.TRUE.equals(expenseForm.getOutlier()));
+            });
+            redirectAttributes.addFlashAttribute("successMessage", "Expense updated successfully.");
+        } catch (ExpenseNotFoundException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "We could not find that expense.");
+        }
+
+        return "redirect:/expenses";
+    }
+
+    @PostMapping("/{expenseId}/delete")
+    public String deleteExpense(@PathVariable Integer expenseId, RedirectAttributes redirectAttributes) {
+        Optional<String> username = currentUsername();
+        if (username.isEmpty()) {
+            return "redirect:/login";
+        }
+
+        try {
+            expenseEntryService.deleteExpenseForUser(username.get(), expenseId);
+            redirectAttributes.addFlashAttribute("successMessage", "Expense deleted successfully.");
+        } catch (ExpenseNotFoundException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "We could not find that expense.");
+        }
+
+        return "redirect:/expenses";
+    }
+
+    private void populateBaseModel(Model model, List<ExpenseEntry> expenses) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        model.addAttribute("user", authentication);
+        model.addAttribute("appName", "Glitterfin");
+        model.addAttribute("expenses", expenses);
+        model.addAttribute("hasExpenses", !expenses.isEmpty());
+    }
+
+    private Optional<String> currentUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserDetails userDetails) {
+            return Optional.ofNullable(userDetails.getUsername());
+        }
+
+        if (principal instanceof String principalName && !"anonymousUser".equalsIgnoreCase(principalName)) {
+            return Optional.of(principalName);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/arobu/glitterfinv2/controller/frontend/HomeController.java
+++ b/src/main/java/arobu/glitterfinv2/controller/frontend/HomeController.java
@@ -6,17 +6,27 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.util.List;
+
 @Controller
 public class HomeController {
 
     @GetMapping("/")
     public String home(Model model) {
         model.addAttribute("appName", "Glitterfin");
-        model.addAttribute("message", "Glitterfin! Finances done with glitter");
+        model.addAttribute("heroTitle", "Finance intelligence for modern teams");
+        model.addAttribute("heroSubtitle", "Track, understand, and optimise your spending with beautiful dashboards and actionable insights.");
+        model.addAttribute("features", List.of(
+                new FeatureCard("Expense visibility", "Gain a clear overview of your latest purchases with rich context and categorisation."),
+                new FeatureCard("Collaboration ready", "Work with your team to flag shared costs and spot outliers before they surprise you."),
+                new FeatureCard("Secure by default", "Enterprise-grade security keeps your financial data protected across the platform.")
+        ));
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         model.addAttribute("user", authentication);
         return "index"; // returns templates/index.html
     }
+
+    public record FeatureCard(String title, String description) { }
 }

--- a/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryForm.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryForm.java
@@ -1,0 +1,115 @@
+package arobu.glitterfinv2.model.dto;
+
+import arobu.glitterfinv2.model.entity.ExpenseEntry;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class ExpenseEntryForm {
+
+    private Integer id;
+
+    @NotNull(message = "Amount is required")
+    @DecimalMin(value = "0.0", inclusive = false, message = "Amount must be greater than 0")
+    private Double amount;
+
+    @Size(max = 60, message = "Category must be 60 characters or less")
+    private String category;
+
+    @Size(max = 120, message = "Merchant must be 120 characters or less")
+    private String merchant;
+
+    @Size(max = 255, message = "Description must be 255 characters or less")
+    private String description;
+
+    @Size(max = 60, message = "Source must be 60 characters or less")
+    private String source;
+
+    private Boolean shared = Boolean.FALSE;
+
+    private Boolean outlier = Boolean.FALSE;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public ExpenseEntryForm setId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public ExpenseEntryForm setAmount(Double amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public ExpenseEntryForm setCategory(String category) {
+        this.category = category;
+        return this;
+    }
+
+    public String getMerchant() {
+        return merchant;
+    }
+
+    public ExpenseEntryForm setMerchant(String merchant) {
+        this.merchant = merchant;
+        return this;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public ExpenseEntryForm setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public ExpenseEntryForm setSource(String source) {
+        this.source = source;
+        return this;
+    }
+
+    public Boolean getShared() {
+        return shared;
+    }
+
+    public ExpenseEntryForm setShared(Boolean shared) {
+        this.shared = shared;
+        return this;
+    }
+
+    public Boolean getOutlier() {
+        return outlier;
+    }
+
+    public ExpenseEntryForm setOutlier(Boolean outlier) {
+        this.outlier = outlier;
+        return this;
+    }
+
+    public static ExpenseEntryForm fromEntity(ExpenseEntry expenseEntry) {
+        return new ExpenseEntryForm()
+                .setId(expenseEntry.getId())
+                .setAmount(expenseEntry.getAmount())
+                .setCategory(expenseEntry.getCategory())
+                .setMerchant(expenseEntry.getMerchant())
+                .setDescription(expenseEntry.getDescription())
+                .setSource(expenseEntry.getSource())
+                .setShared(Boolean.TRUE.equals(expenseEntry.getShared()))
+                .setOutlier(Boolean.TRUE.equals(expenseEntry.getOutlier()));
+    }
+}

--- a/src/main/java/arobu/glitterfinv2/model/repository/ExpenseEntryRepository.java
+++ b/src/main/java/arobu/glitterfinv2/model/repository/ExpenseEntryRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ExpenseEntryRepository extends JpaRepository<ExpenseEntry, Integer> {
 
-    List<ExpenseEntry> findAllByOwner_Username(String ownerUsername);
+    List<ExpenseEntry> findAllByOwner_UsernameOrderByTimestampDesc(String ownerUsername);
+
+    Optional<ExpenseEntry> findByIdAndOwner_Username(Integer id, String ownerUsername);
 }

--- a/src/main/java/arobu/glitterfinv2/service/ExpenseEntryService.java
+++ b/src/main/java/arobu/glitterfinv2/service/ExpenseEntryService.java
@@ -6,11 +6,14 @@ import arobu.glitterfinv2.model.entity.ExpenseOwner;
 import arobu.glitterfinv2.model.entity.Location;
 import arobu.glitterfinv2.model.mapper.ExpenseEntryMapper;
 import arobu.glitterfinv2.model.repository.ExpenseEntryRepository;
+import arobu.glitterfinv2.service.exception.ExpenseNotFoundException;
 import arobu.glitterfinv2.service.exception.OwnerNotFoundException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class ExpenseEntryService {
@@ -34,5 +37,28 @@ public class ExpenseEntryService {
         ExpenseEntry entity = ExpenseEntryMapper.toEntity(expenseEntryApiPostDTO, owner, location);
         LOGGER.info("Persisting expense entry: {}", entity);
         return expenseEntryRepository.save(entity);
+    }
+
+    public List<ExpenseEntry> getExpensesForUser(final String username) {
+        return expenseEntryRepository.findAllByOwner_UsernameOrderByTimestampDesc(username);
+    }
+
+    public ExpenseEntry getExpenseForUser(final String username, final Integer expenseId) throws ExpenseNotFoundException {
+        return expenseEntryRepository.findByIdAndOwner_Username(expenseId, username)
+                .orElseThrow(() -> new ExpenseNotFoundException(expenseId));
+    }
+
+    public ExpenseEntry updateExpenseForUser(final String username,
+                                             final Integer expenseId,
+                                             final java.util.function.Consumer<ExpenseEntry> mutator)
+            throws ExpenseNotFoundException {
+        ExpenseEntry expense = getExpenseForUser(username, expenseId);
+        mutator.accept(expense);
+        return expenseEntryRepository.save(expense);
+    }
+
+    public void deleteExpenseForUser(final String username, final Integer expenseId) throws ExpenseNotFoundException {
+        ExpenseEntry expense = getExpenseForUser(username, expenseId);
+        expenseEntryRepository.delete(expense);
     }
 }

--- a/src/main/java/arobu/glitterfinv2/service/exception/ExpenseNotFoundException.java
+++ b/src/main/java/arobu/glitterfinv2/service/exception/ExpenseNotFoundException.java
@@ -1,0 +1,8 @@
+package arobu.glitterfinv2.service.exception;
+
+public class ExpenseNotFoundException extends Exception {
+
+    public ExpenseNotFoundException(Integer id) {
+        super("Expense with id " + id + " was not found for the current user");
+    }
+}

--- a/src/main/resources/static/css/expenses.css
+++ b/src/main/resources/static/css/expenses.css
@@ -1,0 +1,84 @@
+.expenses-layout {
+    padding: 3rem 0 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.page-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+}
+
+.header-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.expenses-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 1.75rem;
+}
+
+.expense-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+}
+
+.expense-table th,
+.expense-table td {
+    padding: 0.85rem 0.6rem;
+    border-bottom: 1px solid rgba(26, 28, 45, 0.06);
+    text-align: left;
+}
+
+.expense-table th {
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    color: var(--color-muted);
+    background: rgba(93, 95, 239, 0.04);
+}
+
+.expense-table tbody tr:hover {
+    background: rgba(93, 95, 239, 0.04);
+}
+
+.expense-table tr.is-active {
+    background: rgba(93, 95, 239, 0.12);
+}
+
+.expense-table .numeric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+}
+
+.expense-table .actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.expense-table .actions form {
+    display: inline;
+}
+
+@media (max-width: 992px) {
+    .expenses-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 600px) {
+    .expense-table th,
+    .expense-table td {
+        padding: 0.7rem 0.4rem;
+    }
+}

--- a/src/main/resources/static/css/footer.css
+++ b/src/main/resources/static/css/footer.css
@@ -1,17 +1,13 @@
 .site-footer {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-
-    background: #333;
-    color: white;
-    padding: 0.2rem 0 0.2rem;
-    margin-top: auto;
+    background: #0f1022;
+    color: rgba(255, 255, 255, 0.75);
+    padding: 1.5rem 0;
+    margin-top: 4rem;
 }
 
 .footer-bottom {
-    border-top: 1px solid #555;
     text-align: center;
-    font-size: 0.7rem;
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
 }

--- a/src/main/resources/static/css/header.css
+++ b/src/main/resources/static/css/header.css
@@ -1,6 +1,88 @@
-header {
-    background: #333;
-    color: white;
-    padding: 1rem;
-    text-align: center;
+.site-header {
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(12px);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    border-bottom: 1px solid rgba(26, 28, 45, 0.07);
+}
+
+.header-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 0;
+    gap: 2rem;
+}
+
+.brand {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: #1a1c2d;
+    letter-spacing: -0.01em;
+}
+
+.primary-nav {
+    display: flex;
+    gap: 1.5rem;
+    align-items: center;
+    flex: 1;
+}
+
+.primary-nav a {
+    color: #454860;
+    font-weight: 600;
+    font-size: 0.95rem;
+    position: relative;
+    padding-bottom: 0.4rem;
+}
+
+.primary-nav a.is-active::after,
+.primary-nav a:hover::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 3px;
+    background: linear-gradient(135deg, #5d5fef, #7b7df8);
+    border-radius: 999px;
+}
+
+.primary-nav a:hover {
+    color: #1a1c2d;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.auth {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.welcome {
+    color: #6b6f82;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+    .header-inner {
+        flex-wrap: wrap;
+        padding: 0.75rem 0;
+    }
+
+    .primary-nav {
+        order: 3;
+        width: 100%;
+        justify-content: space-around;
+    }
+
+    .header-actions {
+        order: 2;
+    }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1,15 +1,377 @@
+:root {
+    --color-bg: #f7f8fc;
+    --color-surface: #ffffff;
+    --color-accent: #5d5fef;
+    --color-accent-hover: #4748d6;
+    --color-text: #1a1c2d;
+    --color-muted: #6b6f82;
+    --color-border: #e5e7f1;
+    --color-success: #1f9d6a;
+    --color-danger: #d6455d;
+    --radius-lg: 24px;
+    --radius-md: 16px;
+    --radius-sm: 12px;
+    --shadow-soft: 0 24px 60px rgba(26, 28, 45, 0.08);
+    --shadow-card: 0 18px 40px rgba(42, 45, 77, 0.06);
+    --transition: all 0.2s ease;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     margin: 0;
-    padding: 0;
-    background-color: #f5f5f5;
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-family: inherit;
+    line-height: 1.6;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    text-decoration: none;
+}
+
+main {
+    display: block;
+    padding-bottom: 4rem;
 }
 
 .container {
-    max-width: 800px;
+    width: min(1100px, calc(100% - 3rem));
     margin: 0 auto;
-    padding: 20px;
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.7rem 1.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: var(--transition);
+    font-size: 0.95rem;
+}
+
+.btn-primary {
+    background: var(--color-accent);
+    color: white;
+    box-shadow: 0 12px 30px rgba(93, 95, 239, 0.25);
+}
+
+.btn-primary:hover {
+    background: var(--color-accent-hover);
+}
+
+.btn-secondary {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border-color: var(--color-border);
+}
+
+.btn-secondary:hover {
+    background: #eef0fb;
+}
+
+.btn-link {
+    background: none;
+    border: none;
+    padding: 0;
+    font-weight: 600;
+    color: var(--color-accent);
+    cursor: pointer;
+    transition: color 0.2s ease;
+}
+
+.btn-link:hover {
+    color: var(--color-accent-hover);
+}
+
+.btn-link.danger {
+    color: var(--color-danger);
+}
+
+.btn-link.danger:hover {
+    color: #ad3245;
+}
+
+.hero {
+    padding: 5rem 0 3rem;
+    background: linear-gradient(135deg, #f1f2ff 0%, #f6f7fb 50%, #ffffff 100%);
+}
+
+.hero-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 3rem;
+    align-items: center;
+}
+
+.hero-copy h1 {
+    font-size: clamp(2rem, 5vw, 3.2rem);
+    margin-bottom: 1.2rem;
+}
+
+.hero-subtitle {
+    color: var(--color-muted);
+    max-width: 36rem;
+    margin-bottom: 1.8rem;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.hero-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--color-muted);
+    font-size: 0.9rem;
+}
+
+.meta-label {
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.75rem;
+    color: var(--color-muted);
+}
+
+.meta-value {
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-size: 0.75rem;
+    color: var(--color-accent);
+    font-weight: 700;
+    margin-bottom: 0.8rem;
+}
+
+.hero-panel {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-card);
+    overflow: hidden;
+    backdrop-filter: blur(12px);
+}
+
+.panel-heading {
+    padding: 1.2rem 1.5rem;
+    font-weight: 600;
+    border-bottom: 1px solid rgba(99, 102, 241, 0.15);
+}
+
+.panel-body {
+    padding: 1.5rem;
+    display: grid;
+    gap: 1.2rem;
+}
+
+.metric-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-muted);
+}
+
+.metric-value {
+    font-size: 1.8rem;
+    font-weight: 700;
+    margin: 0.3rem 0;
+}
+
+.metric-sub {
+    color: var(--color-success);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.features {
+    padding: 4rem 0 2rem;
+}
+
+.features h2 {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.8rem;
+}
+
+.feature-card {
+    background: var(--color-surface);
+    padding: 2rem;
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-card);
+    border: 1px solid rgba(26, 28, 45, 0.05);
+}
+
+.feature-card h3 {
+    margin-top: 0;
+    margin-bottom: 0.8rem;
+}
+
+.feature-card p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.cta {
+    padding: 3rem 0 0;
+}
+
+.cta-content {
+    background: #1a1c2d;
+    color: white;
+    border-radius: var(--radius-lg);
+    padding: 2.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.cta-content p {
+    max-width: 32rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.subtitle {
+    color: var(--color-muted);
+}
+
+.card {
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-card);
+    border: 1px solid rgba(26, 28, 45, 0.05);
+}
+
+.card-header {
+    padding: 1.5rem 1.75rem 0;
+}
+
+.card-header h2 {
+    margin: 0;
+}
+
+.card-body {
+    padding: 1.5rem 1.75rem 2rem;
+}
+
+.alert {
+    padding: 0.85rem 1.2rem;
+    border-radius: 12px;
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+}
+
+.alert.success {
+    background: rgba(31, 157, 106, 0.12);
+    color: var(--color-success);
+}
+
+.alert.danger {
+    background: rgba(214, 69, 93, 0.12);
+    color: var(--color-danger);
+}
+
+.table-wrapper {
+    overflow-x: auto;
+}
+
+.form-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 1.2rem;
+}
+
+.form-control input,
+.form-control textarea {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: 0.7rem 0.9rem;
+    font: inherit;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-control input:focus,
+.form-control textarea:focus {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 4px rgba(93, 95, 239, 0.12);
+    outline: none;
+}
+
+.form-control textarea {
+    resize: vertical;
+}
+
+.form-error {
+    color: var(--color-danger);
+    font-size: 0.8rem;
+}
+
+.form-row {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.checkbox {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--color-muted);
+}
+
+.checkbox input {
+    width: 16px;
+    height: 16px;
+}
+
+.form-actions {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.empty-state {
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+    .hero {
+        padding-top: 4rem;
+    }
+
+    .cta-content {
+        padding: 2rem;
+    }
+
+    .form-row {
+        flex-direction: column;
+    }
 }

--- a/src/main/resources/templates/expenses/list.html
+++ b/src/main/resources/templates/expenses/list.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Expenses · Glitterfin</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link rel="stylesheet" th:href="@{/css/expenses.css}">
+</head>
+<body>
+<div th:insert="~{fragments/header :: header}"></div>
+
+<main class="container expenses-layout">
+    <section class="page-header">
+        <div>
+            <p class="eyebrow">Expense workspace</p>
+            <h1>Transaction overview</h1>
+            <p class="subtitle">Review recent activity, keep categories tidy, and spot anomalies before they escalate.</p>
+        </div>
+        <div class="header-meta" th:if="${user != null && user.authenticated}">
+            <span class="meta-label">Signed in as</span>
+            <span class="meta-value" th:text="${user.name}">Alex Smith</span>
+        </div>
+    </section>
+
+    <div class="alert success" th:if="${successMessage}" th:text="${successMessage}">Expense updated successfully.</div>
+    <div class="alert danger" th:if="${errorMessage}" th:text="${errorMessage}">Something went wrong.</div>
+
+    <div class="expenses-grid">
+        <section class="card">
+            <div class="card-header">
+                <h2>Latest expenses</h2>
+            </div>
+            <div class="card-body">
+                <p class="empty-state" th:if="${!hasExpenses}">No expenses available yet. Once transactions sync they will appear here automatically.</p>
+                <div class="table-wrapper" th:if="${hasExpenses}">
+                    <table class="expense-table">
+                        <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Merchant</th>
+                            <th>Category</th>
+                            <th>Description</th>
+                            <th>Source</th>
+                            <th>Location</th>
+                            <th class="numeric">Amount</th>
+                            <th>Actions</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr th:each="expense : ${expenses}" th:classappend="${editing != null and editing and editExpenseId != null and editExpenseId == expense.id} ? ' is-active' : ''">
+                            <td th:text="${expense.timestamp != null ? #temporals.format(expense.timestamp, 'MMM d, yyyy') : '—'}">May 13, 2024</td>
+                            <td th:text="${expense.merchant != null ? expense.merchant : '—'}">Acme Supplies</td>
+                            <td th:text="${expense.category != null ? expense.category : 'Uncategorised'}">Office</td>
+                            <td th:text="${expense.description != null ? expense.description : '—'}">Office chairs</td>
+                            <td th:text="${expense.source != null ? expense.source : '—'}">Corporate Card</td>
+                            <td th:text="${expense.location != null ? expense.location.displayName : '—'}">London, UK</td>
+                            <td class="numeric" th:text="${expense.amount != null ? '$' + #numbers.formatDecimal(expense.amount, 1, 2) : '—'}">$120.00</td>
+                            <td class="actions">
+                                <a class="btn-link" th:href="@{'/expenses/' + ${expense.id} + '/edit'}">Edit</a>
+                                <form th:action="@{'/expenses/' + ${expense.id} + '/delete'}" method="post">
+                                    <input type="hidden" th:if="${_csrf != null}" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                    <button type="submit" class="btn-link danger">Delete</button>
+                                </form>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+
+        <aside class="card">
+            <div class="card-header">
+                <h2 th:text="${editing} ? 'Edit expense' : 'Expense details'">Expense details</h2>
+            </div>
+            <div class="card-body">
+                <div th:if="${editing}">
+                    <form th:object="${expenseForm}" th:action="@{'/expenses/' + ${editExpenseId} + '/edit'}" method="post" class="form">
+                        <input type="hidden" th:if="${_csrf != null}" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                        <div class="form-control">
+                            <label for="amount">Amount</label>
+                            <input id="amount" type="number" step="0.01" min="0" th:field="*{amount}" required>
+                            <p class="form-error" th:if="${#fields.hasErrors('amount')}" th:errors="*{amount}">Please enter a valid amount.</p>
+                        </div>
+                        <div class="form-control">
+                            <label for="category">Category</label>
+                            <input id="category" type="text" th:field="*{category}" placeholder="e.g. Operations">
+                            <p class="form-error" th:if="${#fields.hasErrors('category')}" th:errors="*{category}">Invalid category.</p>
+                        </div>
+                        <div class="form-control">
+                            <label for="merchant">Merchant</label>
+                            <input id="merchant" type="text" th:field="*{merchant}" placeholder="Merchant name">
+                            <p class="form-error" th:if="${#fields.hasErrors('merchant')}" th:errors="*{merchant}">Invalid merchant.</p>
+                        </div>
+                        <div class="form-control">
+                            <label for="description">Description</label>
+                            <textarea id="description" rows="3" th:field="*{description}" placeholder="Add additional context"></textarea>
+                            <p class="form-error" th:if="${#fields.hasErrors('description')}" th:errors="*{description}">Invalid description.</p>
+                        </div>
+                        <div class="form-control">
+                            <label for="source">Source</label>
+                            <input id="source" type="text" th:field="*{source}" placeholder="e.g. Corporate Card">
+                            <p class="form-error" th:if="${#fields.hasErrors('source')}" th:errors="*{source}">Invalid source.</p>
+                        </div>
+                        <div class="form-row">
+                            <label class="checkbox">
+                                <input type="checkbox" th:field="*{shared}">
+                                <span>Shared expense</span>
+                            </label>
+                            <label class="checkbox">
+                                <input type="checkbox" th:field="*{outlier}">
+                                <span>Flag as outlier</span>
+                            </label>
+                        </div>
+                        <div class="form-actions">
+                            <button type="submit" class="btn btn-primary">Save changes</button>
+                            <a class="btn btn-secondary" th:href="@{/expenses}">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+                <div class="empty-state" th:unless="${editing}">
+                    <p>Select an expense to review and edit its details. You can also remove transactions directly from the list.</p>
+                </div>
+            </div>
+        </aside>
+    </div>
+</main>
+
+<div th:insert="~{fragments/footer :: footer}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,6 +1,22 @@
 <header th:fragment="header" class="site-header">
     <link rel="stylesheet" th:href="@{/css/header.css}">
-    <nav>
-        <a th:href="@{/}">Home</a>
-    </nav>
+    <div class="header-inner container">
+        <a class="brand" th:href="@{/}">Glitterfin</a>
+        <nav class="primary-nav">
+            <a th:href="@{/}" th:classappend="${#httpServletRequest.requestURI == '/'} ? 'is-active'">Overview</a>
+            <a th:href="@{/expenses}" th:classappend="${#httpServletRequest.requestURI.startsWith('/expenses')} ? 'is-active'">Expenses</a>
+        </nav>
+        <div class="header-actions">
+            <div class="auth" th:if="${user != null && user.authenticated}">
+                <span class="welcome" th:text="'Hello, ' + ${user.name}">Hello, Alex</span>
+                <form th:action="@{/logout}" method="post">
+                    <input type="hidden" th:if="${_csrf != null}" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <button type="submit" class="btn-link">Sign out</button>
+                </form>
+            </div>
+            <div class="auth" th:unless="${user != null && user.authenticated}">
+                <a class="btn btn-secondary" th:href="@{/login}">Sign in</a>
+            </div>
+        </div>
+    </div>
 </header>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -10,20 +10,63 @@
 <div th:insert="~{fragments/header :: header}"></div>
 
 <main>
-    <div class="container">
-        <h2 th:text="${message}">Welcome Message</h2>
-        <a th:href="@{/login}">Login</a>
-
-        <!-- Example of conditional rendering -->
-        <div th:if="${user}" class="user-info">
-            <p>Hello, <span th:text="${user.name}">User</span>!</p>
+    <section class="hero">
+        <div class="hero-content container">
+            <div class="hero-copy">
+                <p class="eyebrow">Glitterfin platform</p>
+                <h1 th:text="${heroTitle}">Finance intelligence for modern teams</h1>
+                <p class="hero-subtitle" th:text="${heroSubtitle}">Track, understand, and optimise your spending with beautiful dashboards and actionable insights.</p>
+                <div class="hero-actions">
+                    <a class="btn btn-primary" th:href="@{/expenses}">View expenses</a>
+                    <a class="btn btn-secondary" th:if="${user == null || !user.authenticated}" th:href="@{/login}">Sign in</a>
+                </div>
+                <div class="hero-meta" th:if="${user != null && user.authenticated}">
+                    <span class="meta-label">Signed in as</span>
+                    <span class="meta-value" th:text="${user.name}">Alex Smith</span>
+                </div>
+            </div>
+            <div class="hero-panel">
+                <div class="panel-heading">Spending snapshot</div>
+                <div class="panel-body">
+                    <div class="metric">
+                        <span class="metric-label">This month</span>
+                        <span class="metric-value">$4,820</span>
+                        <span class="metric-sub">12% under budget</span>
+                    </div>
+                    <div class="metric">
+                        <span class="metric-label">Top category</span>
+                        <span class="metric-value">Operations</span>
+                        <span class="metric-sub">$1,540 spend</span>
+                    </div>
+                    <div class="metric">
+                        <span class="metric-label">Flagged items</span>
+                        <span class="metric-value">3</span>
+                        <span class="metric-sub">Ready for review</span>
+                    </div>
+                </div>
+            </div>
         </div>
+    </section>
 
-        <!-- Example of iteration -->
-        <ul th:if="${items}">
-            <li th:each="item : ${items}" th:text="${item}">Item</li>
-        </ul>
-    </div>
+    <section class="features container">
+        <h2>Everything you need to keep spend in check</h2>
+        <div class="feature-grid">
+            <article class="feature-card" th:each="feature : ${features}">
+                <h3 th:text="${feature.title}">Expense visibility</h3>
+                <p th:text="${feature.description}">Gain a clear overview of your latest purchases with rich context and categorisation.</p>
+            </article>
+        </div>
+    </section>
+
+    <section class="cta container">
+        <div class="cta-content">
+            <div>
+                <h2>Bring clarity to every transaction</h2>
+                <p>Synchronise card feeds, upload receipts, and keep every stakeholder in the loop with a single financial workspace.</p>
+            </div>
+            <a class="btn btn-primary" th:href="@{/expenses}">Go to expense dashboard</a>
+        </div>
+    </section>
 </main>
 
 <div th:insert="~{fragments/footer :: footer}"></div>


### PR DESCRIPTION
## Summary
- add a dedicated expenses dashboard page with an editable table, validation, and delete actions
- expose repository and service helpers for fetching, updating, and removing expenses per user
- refresh the landing page, header, and shared styling to deliver a polished, professional feel

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM because Maven Central is unreachable from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca251140748328b3bc4b965c2adca5