### PR TITLE
Remove redundant authentication checks from expense views

### DIFF
--- a/src/main/java/arobu/glitterfinv2/controller/frontend/ExpenseViewController.java
+++ b/src/main/java/arobu/glitterfinv2/controller/frontend/ExpenseViewController.java
@@ -1,0 +1,106 @@
+package arobu.glitterfinv2.controller.frontend;
+
+import arobu.glitterfinv2.model.dto.ExpenseEntryUpdateForm;
+import arobu.glitterfinv2.model.entity.ExpenseEntry;
+import arobu.glitterfinv2.service.ExpenseEntryService;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+import java.util.Optional;
+
+@Controller
+@RequestMapping("/expenses")
+public class ExpenseViewController {
+
+    private final ExpenseEntryService expenseEntryService;
+
+    public ExpenseViewController(ExpenseEntryService expenseEntryService) {
+        this.expenseEntryService = expenseEntryService;
+    }
+
+    @GetMapping
+    public String expenses(Model model, Authentication authentication) {
+        List<ExpenseEntry> expenses = expenseEntryService.getExpensesForUser(authentication.getName());
+
+        model.addAttribute("appName", "Glitterfin");
+        model.addAttribute("expenses", expenses);
+
+        return "expenses";
+    }
+
+    @GetMapping("/{id}")
+    public String viewExpense(@PathVariable("id") Integer expenseId,
+                              Model model,
+                              Authentication authentication,
+                              RedirectAttributes redirectAttributes) {
+        Optional<ExpenseEntry> expenseEntry = expenseEntryService.getExpenseForUser(expenseId, authentication.getName());
+
+        if (expenseEntry.isEmpty()) {
+            redirectAttributes.addFlashAttribute("expenseMessage", "Unable to locate the requested expense.");
+            return "redirect:/expenses";
+        }
+
+        model.addAttribute("appName", "Glitterfin");
+        model.addAttribute("expense", expenseEntry.get());
+
+        return "expense-detail";
+    }
+
+    @GetMapping("/{id}/edit")
+    public String editExpense(@PathVariable("id") Integer expenseId,
+                              Model model,
+                              Authentication authentication,
+                              RedirectAttributes redirectAttributes) {
+        Optional<ExpenseEntry> expenseEntry = expenseEntryService.getExpenseForUser(expenseId, authentication.getName());
+
+        if (expenseEntry.isEmpty()) {
+            redirectAttributes.addFlashAttribute("expenseMessage", "Unable to locate the requested expense.");
+            return "redirect:/expenses";
+        }
+
+        model.addAttribute("appName", "Glitterfin");
+        model.addAttribute("expense", expenseEntry.get());
+        model.addAttribute("expenseForm", ExpenseEntryUpdateForm.fromExpenseEntry(expenseEntry.get()));
+
+        return "expense-edit";
+    }
+
+    @PostMapping("/{id}/edit")
+    public String updateExpense(@PathVariable("id") Integer expenseId,
+                                @ModelAttribute("expenseForm") ExpenseEntryUpdateForm expenseForm,
+                                Authentication authentication,
+                                RedirectAttributes redirectAttributes) {
+        boolean updated = expenseEntryService
+                .updateExpenseForUser(expenseId, authentication.getName(), expenseForm)
+                .isPresent();
+
+        String message = updated
+                ? "Expense updated successfully."
+                : "Unable to update the expense. Please try again.";
+        redirectAttributes.addFlashAttribute("expenseMessage", message);
+
+        return "redirect:/expenses";
+    }
+
+    @PostMapping("/{id}/delete")
+    public String deleteExpense(@PathVariable("id") Integer expenseId,
+                                Authentication authentication,
+                                RedirectAttributes redirectAttributes) {
+        boolean deleted = expenseEntryService.deleteExpenseForUser(expenseId, authentication.getName());
+        String message = deleted
+                ? "Expense deleted successfully."
+                : "Unable to delete the expense. It may have already been removed.";
+
+        redirectAttributes.addFlashAttribute("expenseMessage", message);
+        return "redirect:/expenses";
+    }
+
+}

--- a/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryUpdateForm.java
+++ b/src/main/java/arobu/glitterfinv2/model/dto/ExpenseEntryUpdateForm.java
@@ -1,0 +1,160 @@
+package arobu.glitterfinv2.model.dto;
+
+import arobu.glitterfinv2.model.entity.ExpenseEntry;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ExpenseEntryUpdateForm {
+
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+
+    private String description;
+    private String category;
+    private String merchant;
+    private BigDecimal amount;
+    private String timestamp;
+    private String timezone;
+    private String source;
+    private String receiptData;
+    private String details;
+    private Boolean shared;
+    private Boolean outlier;
+
+    public static ExpenseEntryUpdateForm fromExpenseEntry(ExpenseEntry expenseEntry) {
+        ExpenseEntryUpdateForm form = new ExpenseEntryUpdateForm();
+        form.setDescription(expenseEntry.getDescription());
+        form.setCategory(expenseEntry.getCategory());
+        form.setMerchant(expenseEntry.getMerchant());
+        form.setAmount(normalizeAmount(expenseEntry.getAmount()));
+
+        if (expenseEntry.getTimestamp() != null) {
+            ZonedDateTime timestamp = expenseEntry.getTimestamp();
+            ZoneId zoneId = resolveZone(expenseEntry);
+            form.setTimestamp(timestamp.withZoneSameInstant(zoneId).format(TIMESTAMP_FORMATTER));
+            form.setTimezone(zoneId.getId());
+        } else {
+            form.setTimezone(expenseEntry.getTimezone());
+        }
+
+        form.setSource(expenseEntry.getSource());
+        form.setReceiptData(expenseEntry.getReceiptData());
+        form.setDetails(expenseEntry.getDetails());
+        form.setShared(expenseEntry.getShared());
+        form.setOutlier(expenseEntry.getOutlier());
+
+        return form;
+    }
+
+    private static ZoneId resolveZone(ExpenseEntry expenseEntry) {
+        if (expenseEntry.getTimezone() != null && !expenseEntry.getTimezone().isBlank()) {
+            try {
+                return ZoneId.of(expenseEntry.getTimezone());
+            } catch (DateTimeException ignored) {
+                // fall through to the timestamp zone
+            }
+        }
+
+        return expenseEntry.getTimestamp().getZone();
+    }
+
+    private static BigDecimal normalizeAmount(Double amount) {
+        if (amount == null) {
+            return null;
+        }
+
+        return BigDecimal.valueOf(amount).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getMerchant() {
+        return merchant;
+    }
+
+    public void setMerchant(String merchant) {
+        this.merchant = merchant;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getReceiptData() {
+        return receiptData;
+    }
+
+    public void setReceiptData(String receiptData) {
+        this.receiptData = receiptData;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    public void setDetails(String details) {
+        this.details = details;
+    }
+
+    public Boolean getShared() {
+        return shared;
+    }
+
+    public void setShared(Boolean shared) {
+        this.shared = shared;
+    }
+
+    public Boolean getOutlier() {
+        return outlier;
+    }
+
+    public void setOutlier(Boolean outlier) {
+        this.outlier = outlier;
+    }
+}

--- a/src/main/java/arobu/glitterfinv2/model/repository/ExpenseEntryRepository.java
+++ b/src/main/java/arobu/glitterfinv2/model/repository/ExpenseEntryRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ExpenseEntryRepository extends JpaRepository<ExpenseEntry, Integer> {
 
     List<ExpenseEntry> findAllByOwner_Username(String ownerUsername);
+
+    Optional<ExpenseEntry> findByIdAndOwner_Username(Integer id, String ownerUsername);
 }

--- a/src/main/java/arobu/glitterfinv2/service/ExpenseEntryService.java
+++ b/src/main/java/arobu/glitterfinv2/service/ExpenseEntryService.java
@@ -1,6 +1,7 @@
 package arobu.glitterfinv2.service;
 
 import arobu.glitterfinv2.model.dto.ExpenseEntryApiPostDTO;
+import arobu.glitterfinv2.model.dto.ExpenseEntryUpdateForm;
 import arobu.glitterfinv2.model.entity.ExpenseEntry;
 import arobu.glitterfinv2.model.entity.ExpenseOwner;
 import arobu.glitterfinv2.model.entity.Location;
@@ -9,8 +10,16 @@ import arobu.glitterfinv2.model.repository.ExpenseEntryRepository;
 import arobu.glitterfinv2.service.exception.OwnerNotFoundException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ExpenseEntryService {
@@ -34,5 +43,116 @@ public class ExpenseEntryService {
         ExpenseEntry entity = ExpenseEntryMapper.toEntity(expenseEntryApiPostDTO, owner, location);
         LOGGER.info("Persisting expense entry: {}", entity);
         return expenseEntryRepository.save(entity);
+    }
+
+    public List<ExpenseEntry> getExpensesForUser(final String username) {
+        if (username == null || username.isBlank()) {
+            LOGGER.debug("Requested expenses for empty username");
+            return Collections.emptyList();
+        }
+
+        LOGGER.debug("Fetching expenses for user: {}", username);
+        return expenseEntryRepository.findAllByOwner_Username(username);
+    }
+
+    public Optional<ExpenseEntry> getExpenseForUser(final Integer expenseId, final String username) {
+        if (expenseId == null || username == null || username.isBlank()) {
+            LOGGER.debug("Attempted to fetch expense with invalid data. id: {}, username: {}", expenseId, username);
+            return Optional.empty();
+        }
+
+        LOGGER.debug("Fetching expense {} for user {}", expenseId, username);
+        return expenseEntryRepository.findByIdAndOwner_Username(expenseId, username);
+    }
+
+    public Optional<ExpenseEntry> updateExpenseForUser(final Integer expenseId, final String username, final ExpenseEntryUpdateForm form) {
+        if (form == null) {
+            LOGGER.warn("Attempted to update expense {} for user {} with empty form", expenseId, username);
+            return Optional.empty();
+        }
+
+        return getExpenseForUser(expenseId, username).map(expenseEntry -> {
+            expenseEntry.setDescription(form.getDescription());
+            expenseEntry.setCategory(form.getCategory());
+            expenseEntry.setMerchant(form.getMerchant());
+            expenseEntry.setAmount(form.getAmount() != null ? form.getAmount().doubleValue() : null);
+            expenseEntry.setSource(form.getSource());
+            expenseEntry.setReceiptData(form.getReceiptData());
+            expenseEntry.setDetails(form.getDetails());
+
+            if (form.getShared() != null) {
+                expenseEntry.setShared(form.getShared());
+            }
+
+            if (form.getOutlier() != null) {
+                expenseEntry.setOutlier(form.getOutlier());
+            }
+
+            applyTimestampUpdates(expenseEntry, form);
+
+            LOGGER.info("Updating expense {} for user {}", expenseId, username);
+            return expenseEntryRepository.save(expenseEntry);
+        });
+    }
+
+    public boolean deleteExpenseForUser(final Integer expenseId, final String username) {
+        Optional<ExpenseEntry> expenseEntry = getExpenseForUser(expenseId, username);
+
+        if (expenseEntry.isEmpty()) {
+            LOGGER.warn("Attempted to delete missing expense {} for user {}", expenseId, username);
+            return false;
+        }
+
+        LOGGER.info("Deleting expense {} for user {}", expenseId, username);
+        expenseEntryRepository.delete(expenseEntry.get());
+        return true;
+    }
+
+    private void applyTimestampUpdates(ExpenseEntry expenseEntry, ExpenseEntryUpdateForm form) {
+        String timestampValue = form.getTimestamp();
+        String timezoneValue = form.getTimezone();
+
+        ZoneId targetZone = resolveTargetZone(expenseEntry, timezoneValue);
+
+        if (timestampValue != null && !timestampValue.isBlank()) {
+            try {
+                LocalDateTime localDateTime = LocalDateTime.parse(timestampValue);
+                ZonedDateTime updatedTimestamp = localDateTime.atZone(targetZone);
+                expenseEntry.setTimestamp(updatedTimestamp);
+                expenseEntry.setTimezone(updatedTimestamp.getZone().getId());
+                return;
+            } catch (DateTimeParseException e) {
+                LOGGER.warn("Failed to parse timestamp '{}' for expense {}", timestampValue, expenseEntry.getId(), e);
+            }
+        }
+
+        if (timezoneValue != null && !timezoneValue.isBlank()) {
+            if (expenseEntry.getTimestamp() != null) {
+                expenseEntry.setTimestamp(expenseEntry.getTimestamp().withZoneSameInstant(targetZone));
+            }
+            expenseEntry.setTimezone(targetZone.getId());
+        }
+    }
+
+    private ZoneId resolveTargetZone(ExpenseEntry expenseEntry, String requestedZone) {
+        if (requestedZone != null && !requestedZone.isBlank()) {
+            try {
+                return ZoneId.of(requestedZone);
+            } catch (DateTimeException e) {
+                LOGGER.warn("Invalid timezone '{}' provided for expense {}", requestedZone, expenseEntry.getId(), e);
+            }
+        }
+
+        if (expenseEntry.getTimezone() != null && !expenseEntry.getTimezone().isBlank()) {
+            try {
+                return ZoneId.of(expenseEntry.getTimezone());
+            } catch (DateTimeException e) {
+                LOGGER.warn("Stored timezone '{}' for expense {} is invalid", expenseEntry.getTimezone(), expenseEntry.getId(), e);
+            }
+        }
+
+        return expenseEntry.getTimestamp() != null
+                ? expenseEntry.getTimestamp().getZone()
+                : ZoneId.systemDefault();
     }
 }

--- a/src/main/resources/static/css/expense-detail.css
+++ b/src/main/resources/static/css/expense-detail.css
@@ -1,0 +1,168 @@
+.expense-detail {
+    max-width: 920px;
+    margin: 2.5rem auto;
+    padding: 2.5rem;
+    background: #ffffff;
+    border-radius: 14px;
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.1);
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #2563eb;
+    text-decoration: none;
+    font-weight: 600;
+    margin-bottom: 1.5rem;
+}
+
+.back-link:hover,
+.back-link:focus {
+    text-decoration: underline;
+}
+
+.expense-detail__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.expense-detail__header h1 {
+    margin: 0;
+    font-size: 2.1rem;
+    color: #1f2937;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.65rem 1.6rem;
+    border-radius: 10px;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+    border: none;
+}
+
+.btn:hover,
+.btn:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 16px rgba(15, 23, 42, 0.12);
+}
+
+.btn-edit {
+    background: #2563eb;
+    color: #ffffff;
+}
+
+.expense-detail__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1.5rem;
+    padding: 1.5rem;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    margin-bottom: 2rem;
+}
+
+.summary-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.summary-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #64748b;
+}
+
+.summary-value {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.summary-helper {
+    font-size: 0.85rem;
+    color: #475569;
+}
+
+.expense-detail__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.75rem;
+}
+
+.detail-card {
+    background: #fdfdfd;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.05);
+}
+
+.detail-card h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 1.15rem;
+    color: #1f2937;
+}
+
+dl {
+    margin: 0;
+}
+
+.detail-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.detail-row:last-child {
+    border-bottom: none;
+}
+
+.detail-row dt {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #475569;
+}
+
+.detail-row dd {
+    margin: 0;
+    font-size: 1rem;
+    color: #1f2937;
+    word-break: break-word;
+}
+
+.detail-card p {
+    margin: 0;
+    color: #1f2937;
+    line-height: 1.6;
+}
+
+@media (max-width: 640px) {
+    .expense-detail {
+        padding: 1.75rem;
+        margin: 1.5rem;
+    }
+
+    .expense-detail__summary {
+        grid-template-columns: 1fr;
+    }
+
+    .expense-detail__grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/main/resources/static/css/expense-edit.css
+++ b/src/main/resources/static/css/expense-edit.css
@@ -1,0 +1,153 @@
+.expense-edit-container {
+    max-width: 680px;
+    margin: 2.5rem auto;
+    padding: 2.25rem;
+    background: #ffffff;
+    border-radius: 14px;
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.1);
+}
+
+.expense-edit-container h1 {
+    margin-top: 0;
+    font-size: 2.1rem;
+    color: #1f2937;
+}
+
+.expense-summary {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 1.25rem;
+    margin-bottom: 1.75rem;
+    color: #475569;
+}
+
+.expense-summary p {
+    margin: 0.25rem 0;
+}
+
+.expense-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.form-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.form-row label {
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.form-row input,
+.form-row textarea {
+    padding: 0.75rem 1rem;
+    border-radius: 10px;
+    border: 1px solid #cbd5f5;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-row textarea {
+    min-height: 120px;
+    resize: vertical;
+}
+
+.form-row input:focus,
+.form-row textarea:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+    outline: none;
+}
+
+.checkbox-row {
+    flex-direction: row;
+    gap: 2rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.checkbox-row .checkbox {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+    color: #1f2937;
+}
+
+.checkbox-row input[type="checkbox"] {
+    width: 1.1rem;
+    height: 1.1rem;
+}
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+}
+
+.btn-primary,
+.btn-secondary,
+.btn-delete {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.6rem 1.6rem;
+    border-radius: 10px;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+    border: none;
+}
+
+.btn-primary {
+    background: #2563eb;
+    color: #ffffff;
+}
+
+.btn-secondary {
+    background: #e2e8f0;
+    color: #1f2937;
+}
+
+.btn-delete {
+    background: #dc2626;
+    color: #ffffff;
+}
+
+.btn-primary:hover,
+.btn-secondary:hover,
+.btn-delete:hover,
+.btn-primary:focus,
+.btn-secondary:focus,
+.btn-delete:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 16px rgba(15, 23, 42, 0.12);
+}
+
+.delete-form {
+    margin-top: 2rem;
+    display: flex;
+    justify-content: flex-end;
+}
+
+@media (max-width: 640px) {
+    .expense-edit-container {
+        margin: 1.5rem;
+        padding: 1.5rem;
+    }
+
+    .form-actions {
+        flex-direction: column-reverse;
+        align-items: stretch;
+    }
+
+    .delete-form {
+        justify-content: stretch;
+    }
+}

--- a/src/main/resources/static/css/expenses.css
+++ b/src/main/resources/static/css/expenses.css
@@ -1,0 +1,128 @@
+.expenses-container {
+    max-width: 1100px;
+    margin: 2rem auto;
+    padding: 2rem;
+    background: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+}
+
+.expenses-container h1 {
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 2rem;
+    color: #1f2937;
+}
+
+.auth-message,
+.empty-state,
+.feedback {
+    padding: 1.5rem;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    color: #475569;
+    text-align: center;
+}
+
+.feedback {
+    background: #ecfdf5;
+    border-color: #bbf7d0;
+    color: #166534;
+    margin-bottom: 1.5rem;
+}
+
+.expenses-table-wrapper {
+    overflow-x: auto;
+}
+
+.expenses-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 720px;
+}
+
+.expenses-table thead {
+    background: #1f2937;
+    color: #f9fafb;
+}
+
+.expenses-table th,
+.expenses-table td {
+    padding: 0.85rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid #e2e8f0;
+    font-size: 0.95rem;
+}
+
+.expenses-table tbody tr[data-href] {
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.expenses-table tbody tr[data-href]:hover {
+    background: #f8fafc;
+}
+
+.expenses-table tbody tr[data-href]:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: -3px;
+    background: #eff6ff;
+}
+
+.expenses-table tbody tr[data-href] td.actions {
+    cursor: default;
+}
+
+.expenses-table td.actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.inline-form {
+    margin: 0;
+}
+
+.btn {
+    display: inline-block;
+    padding: 0.5rem 0.9rem;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn:hover,
+.btn:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 12px rgba(15, 23, 42, 0.12);
+}
+
+.btn-edit {
+    background: #2563eb;
+    color: #ffffff;
+}
+
+.btn-delete {
+    background: #dc2626;
+    color: #ffffff;
+}
+
+@media (max-width: 768px) {
+    .expenses-container {
+        padding: 1.5rem;
+        margin: 1.5rem;
+    }
+
+    .expenses-table {
+        min-width: 100%;
+    }
+
+    .expenses-table td.actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}

--- a/src/main/resources/static/css/footer.css
+++ b/src/main/resources/static/css/footer.css
@@ -1,13 +1,9 @@
 .site-footer {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-
     background: #333;
     color: white;
     padding: 0.2rem 0 0.2rem;
     margin-top: auto;
+    width: 100%;
 }
 
 .footer-bottom {

--- a/src/main/resources/static/css/header.css
+++ b/src/main/resources/static/css/header.css
@@ -1,6 +1,110 @@
-header {
-    background: #333;
-    color: white;
-    padding: 1rem;
-    text-align: center;
+.site-header {
+    background: #1f2937;
+    color: #f9fafb;
+    padding: 1rem 0;
+    box-shadow: 0 2px 4px rgba(15, 23, 42, 0.2);
+}
+
+
+.site-header .header-inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+}
+
+.site-header .brand {
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: #facc15;
+    text-decoration: none;
+    letter-spacing: 0.03em;
+}
+
+
+.site-header .primary-nav {
+    display: flex;
+    gap: 1.5rem;
+}
+
+.site-header .primary-nav a {
+    color: #f9fafb;
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.2s ease, border-bottom-color 0.2s ease;
+    padding-bottom: 0.2rem;
+    border-bottom: 2px solid transparent;
+}
+
+.site-header .primary-nav a:hover,
+.site-header .primary-nav a:focus {
+    color: #facc15;
+    border-bottom-color: #facc15;
+}
+
+.site-header .auth-controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.site-header .auth-controls a,
+.site-header .logout-button {
+    color: #f9fafb;
+    font-weight: 500;
+    text-decoration: none;
+}
+
+.site-header .login-link {
+    border: 1px solid transparent;
+    padding: 0.35rem 0.75rem;
+    border-radius: 9999px;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.site-header .login-link:hover,
+.site-header .login-link:focus {
+    background-color: rgba(250, 204, 21, 0.15);
+    border-color: #facc15;
+    color: #facc15;
+}
+
+.site-header .logout-form {
+    margin: 0;
+}
+
+.site-header .logout-button {
+    background: transparent;
+    border: 1px solid rgba(248, 250, 252, 0.4);
+    border-radius: 9999px;
+    padding: 0.35rem 0.9rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.site-header .logout-button:hover,
+.site-header .logout-button:focus {
+    background-color: rgba(248, 250, 252, 0.15);
+    border-color: #facc15;
+    color: #facc15;
+}
+
+@media (max-width: 640px) {
+    .site-header .header-inner {
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .site-header .primary-nav {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .site-header .auth-controls {
+        width: 100%;
+        justify-content: center;
+    }
 }

--- a/src/main/resources/static/css/login.css
+++ b/src/main/resources/static/css/login.css
@@ -1,0 +1,128 @@
+:root {
+    color-scheme: light dark;
+}
+
+body.auth-body {
+    margin: 0;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: linear-gradient(180deg, #0f172a 0%, #1f2937 50%, #111827 100%);
+    min-height: 100vh;
+    color: #e2e8f0;
+    display: flex;
+    flex-direction: column;
+}
+
+.auth-main {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem 1.5rem;
+}
+
+.auth-card {
+    width: min(420px, 100%);
+    background: rgba(15, 23, 42, 0.88);
+    border-radius: 1.25rem;
+    padding: 2.75rem 2.5rem;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+    backdrop-filter: blur(12px);
+}
+
+.auth-title {
+    margin: 0 0 0.25rem;
+    font-size: 2rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+}
+
+.auth-subtitle {
+    margin: 0 0 2rem;
+    color: rgba(226, 232, 240, 0.75);
+    font-size: 0.95rem;
+}
+
+.auth-alert {
+    padding: 0.9rem 1rem;
+    border-radius: 0.75rem;
+    font-size: 0.9rem;
+    margin-bottom: 1.25rem;
+    border: 1px solid transparent;
+}
+
+.auth-alert--error {
+    background: rgba(248, 113, 113, 0.12);
+    border-color: rgba(248, 113, 113, 0.35);
+    color: #fecaca;
+}
+
+.auth-alert--success {
+    background: rgba(134, 239, 172, 0.12);
+    border-color: rgba(134, 239, 172, 0.35);
+    color: #bbf7d0;
+}
+
+.auth-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+}
+
+.form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.form-field label {
+    font-weight: 500;
+    font-size: 0.9rem;
+    color: rgba(226, 232, 240, 0.9);
+}
+
+.form-field input {
+    border-radius: 0.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    padding: 0.85rem 1rem;
+    background: rgba(15, 23, 42, 0.6);
+    color: #e2e8f0;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.form-field input:focus {
+    outline: none;
+    border-color: #facc15;
+    box-shadow: 0 0 0 3px rgba(250, 204, 21, 0.25);
+    background: rgba(30, 41, 59, 0.9);
+}
+
+.auth-submit {
+    margin-top: 0.75rem;
+    background: linear-gradient(135deg, #facc15, #f97316);
+    border: none;
+    color: #111827;
+    font-weight: 600;
+    font-size: 1rem;
+    padding: 0.9rem 1rem;
+    border-radius: 0.85rem;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.auth-submit:hover,
+.auth-submit:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 24px rgba(249, 115, 22, 0.25);
+    outline: none;
+}
+
+@media (max-width: 480px) {
+    .auth-card {
+        padding: 2.25rem 1.75rem;
+    }
+
+    .auth-title {
+        font-size: 1.75rem;
+    }
+}

--- a/src/main/resources/static/js/expenses.js
+++ b/src/main/resources/static/js/expenses.js
@@ -1,0 +1,51 @@
+(function () {
+    function navigateToRow(row) {
+        const url = row.getAttribute('data-href');
+        if (url) {
+            window.location.href = url;
+        }
+    }
+
+    function isInteractiveElement(target) {
+        return target.closest('a, button, form, input, select, textarea');
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const rows = document.querySelectorAll('tr[data-href]');
+
+        rows.forEach(function (row) {
+            row.classList.add('clickable');
+            row.setAttribute('tabindex', '0');
+            row.setAttribute('role', 'link');
+
+            const expenseName = row.dataset.expenseName;
+            if (expenseName) {
+                row.setAttribute('aria-label', 'View details for ' + expenseName);
+            }
+
+            row.addEventListener('click', function (event) {
+                if (isInteractiveElement(event.target)) {
+                    return;
+                }
+
+                navigateToRow(row);
+            });
+
+            row.addEventListener('keydown', function (event) {
+                if (isInteractiveElement(event.target)) {
+                    return;
+                }
+
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    navigateToRow(row);
+                }
+
+                if (event.key === ' ') {
+                    event.preventDefault();
+                    navigateToRow(row);
+                }
+            });
+        });
+    });
+})();

--- a/src/main/resources/templates/expense-detail.html
+++ b/src/main/resources/templates/expense-detail.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${appName} + ' | Expense Details'">Glitterfin | Expense Details</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link rel="stylesheet" th:href="@{/css/expense-detail.css}">
+</head>
+<body>
+<div th:insert="~{fragments/header :: header}"></div>
+
+<main>
+    <section class="expense-detail" th:if="${expense != null}">
+        <a class="back-link" th:href="@{/expenses}">
+            <span aria-hidden="true">&larr;</span>
+            Back to expenses
+        </a>
+
+        <header class="expense-detail__header">
+            <h1 th:text="${expense.description != null ? expense.description : 'Expense details'}">Expense details</h1>
+            <div class="expense-detail__actions">
+                <a class="btn btn-edit" th:href="@{/expenses/{id}/edit(id=${expense.id})}">Edit expense</a>
+            </div>
+        </header>
+
+        <div class="expense-detail__summary">
+            <div class="summary-item">
+                <span class="summary-label">Amount</span>
+                <span class="summary-value"
+                      th:text="${expense.amount != null ? '$' + #numbers.formatDecimal(expense.amount, 1, 'COMMA', 2, 'POINT') : '—'}">
+                    $0.00
+                </span>
+            </div>
+            <div class="summary-item">
+                <span class="summary-label">When</span>
+                <span class="summary-value" th:text="${expense.timestamp != null ? #temporals.format(expense.timestamp, 'MMM d, yyyy HH:mm') : '—'}">
+                    Mar 10, 2024 09:15
+                </span>
+                <span class="summary-helper" th:if="${expense.timezone != null}" th:text="${expense.timezone}">UTC</span>
+            </div>
+            <div class="summary-item">
+                <span class="summary-label">Category</span>
+                <span class="summary-value" th:text="${expense.category != null ? expense.category : '—'}">Food</span>
+            </div>
+            <div class="summary-item">
+                <span class="summary-label">Merchant</span>
+                <span class="summary-value" th:text="${expense.merchant != null ? expense.merchant : '—'}">Local Cafe</span>
+            </div>
+        </div>
+
+        <div class="expense-detail__grid">
+            <article class="detail-card">
+                <h2>General information</h2>
+                <dl>
+                    <div class="detail-row">
+                        <dt>Source</dt>
+                        <dd th:text="${expense.source != null ? expense.source : '—'}">Bank import</dd>
+                    </div>
+                    <div class="detail-row">
+                        <dt>Shared expense</dt>
+                        <dd th:text="${expense.shared != null && expense.shared ? 'Yes' : 'No'}">No</dd>
+                    </div>
+                    <div class="detail-row">
+                        <dt>Flagged as outlier</dt>
+                        <dd th:text="${expense.outlier != null && expense.outlier ? 'Yes' : 'No'}">No</dd>
+                    </div>
+                    <div class="detail-row">
+                        <dt>Receipt data</dt>
+                        <dd th:text="${expense.receiptData != null ? expense.receiptData : '—'}">receipt-12345</dd>
+                    </div>
+                </dl>
+            </article>
+
+            <article class="detail-card">
+                <h2>Details</h2>
+                <p th:text="${expense.details != null ? expense.details : 'No additional details provided.'}">
+                    Notes about this expense will appear here.
+                </p>
+            </article>
+
+            <article class="detail-card" th:if="${expense.location != null}">
+                <h2>Location</h2>
+                <dl>
+                    <div class="detail-row">
+                        <dt>Display name</dt>
+                        <dd th:text="${expense.location.displayName != null ? expense.location.displayName : '—'}">123 Main Street</dd>
+                    </div>
+                    <div class="detail-row">
+                        <dt>City</dt>
+                        <dd th:text="${expense.location.city != null ? expense.location.city : '—'}">Springfield</dd>
+                    </div>
+                    <div class="detail-row">
+                        <dt>Country</dt>
+                        <dd th:text="${expense.location.country != null ? expense.location.country : '—'}">USA</dd>
+                    </div>
+                    <div class="detail-row" th:if="${expense.location.latitude != null && expense.location.longitude != null}">
+                        <dt>Coordinates</dt>
+                        <dd th:text="${expense.location.latitude + ', ' + expense.location.longitude}">0, 0</dd>
+                    </div>
+                </dl>
+            </article>
+        </div>
+    </section>
+</main>
+
+<div th:insert="~{fragments/footer :: footer}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/expense-edit.html
+++ b/src/main/resources/templates/expense-edit.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${appName} + ' | Edit Expense'">Glitterfin | Edit Expense</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link rel="stylesheet" th:href="@{/css/expense-edit.css}">
+</head>
+<body>
+<div th:insert="~{fragments/header :: header}"></div>
+
+<main>
+    <section class="expense-edit-container">
+        <h1>Edit Expense</h1>
+
+        <div class="expense-summary">
+            <p><strong>Current Description:</strong> <span th:text="${expense.description != null ? expense.description : '—'}">Coffee</span></p>
+            <p><strong>Recorded On:</strong>
+                <span th:text="${expense.timestamp != null ? #temporals.format(expense.timestamp, 'MMM d, yyyy HH:mm') : '—'}">Mar 10, 2024 09:15</span>
+            </p>
+            <p><strong>Timezone:</strong> <span th:text="${expense.timezone != null ? expense.timezone : '—'}">UTC</span></p>
+            <p><strong>Source:</strong> <span th:text="${expense.source != null ? expense.source : '—'}">Card</span></p>
+            <p><strong>Shared:</strong> <span th:text="${expense.shared != null && expense.shared ? 'Yes' : 'No'}">No</span></p>
+            <p><strong>Outlier:</strong> <span th:text="${expense.outlier != null && expense.outlier ? 'Yes' : 'No'}">No</span></p>
+        </div>
+
+        <form th:action="@{/expenses/{id}/edit(id=${expense.id})}" th:object="${expenseForm}" method="post" class="expense-form">
+            <div class="form-row">
+                <label for="description">Description</label>
+                <input type="text" id="description" th:field="*{description}" placeholder="What was this expense for?" required>
+            </div>
+
+            <div class="form-row">
+                <label for="category">Category</label>
+                <input type="text" id="category" th:field="*{category}" placeholder="e.g., Food, Travel" required>
+            </div>
+
+            <div class="form-row">
+                <label for="merchant">Merchant</label>
+                <input type="text" id="merchant" th:field="*{merchant}" placeholder="Where did you spend?" required>
+            </div>
+
+            <div class="form-row">
+                <label for="amount">Amount</label>
+                <input type="number" id="amount" th:field="*{amount}" step="0.01" min="0" placeholder="0.00" required>
+            </div>
+
+            <div class="form-row">
+                <label for="timestamp">Date &amp; Time</label>
+                <input type="datetime-local" id="timestamp" th:field="*{timestamp}" required>
+            </div>
+
+            <div class="form-row">
+                <label for="timezone">Timezone</label>
+                <input type="text" id="timezone" th:field="*{timezone}" placeholder="e.g., UTC or America/New_York">
+            </div>
+
+            <div class="form-row">
+                <label for="source">Source</label>
+                <input type="text" id="source" th:field="*{source}" placeholder="How was this recorded?">
+            </div>
+
+            <div class="form-row">
+                <label for="receiptData">Receipt Data</label>
+                <textarea id="receiptData" th:field="*{receiptData}" rows="3" placeholder="Paste receipt data or notes"></textarea>
+            </div>
+
+            <div class="form-row">
+                <label for="details">Details</label>
+                <textarea id="details" th:field="*{details}" rows="3" placeholder="Add any extra context"></textarea>
+            </div>
+
+            <div class="form-row checkbox-row">
+                <label class="checkbox">
+                    <input type="checkbox" th:field="*{shared}">
+                    <span>Shared expense</span>
+                </label>
+                <label class="checkbox">
+                    <input type="checkbox" th:field="*{outlier}">
+                    <span>Mark as outlier</span>
+                </label>
+            </div>
+
+            <div class="form-actions">
+                <a th:href="@{/expenses}" class="btn-secondary">Cancel</a>
+                <button type="submit" class="btn-primary">Save Changes</button>
+            </div>
+        </form>
+
+        <form th:action="@{/expenses/{id}/delete(id=${expense.id})}"
+              method="post"
+              class="delete-form"
+              onsubmit="return confirm('Are you sure you want to delete this expense? This action cannot be undone.');">
+            <button type="submit" class="btn-delete">Delete Expense</button>
+        </form>
+    </section>
+</main>
+
+<div th:insert="~{fragments/footer :: footer}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/expenses.html
+++ b/src/main/resources/templates/expenses.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${appName} + ' | Expenses'">Glitterfin | Expenses</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link rel="stylesheet" th:href="@{/css/expenses.css}">
+</head>
+<body>
+<div th:insert="~{fragments/header :: header}"></div>
+
+<main>
+    <section class="expenses-container">
+        <h1>Expenses</h1>
+
+        <div th:if="${expenseMessage}" class="feedback" th:text="${expenseMessage}">
+            Expense updated successfully.
+        </div>
+
+        <div th:if="${#lists.isEmpty(expenses)}" class="empty-state">
+            <p>No expenses recorded yet. Start by adding a new one!</p>
+        </div>
+
+        <div th:if="${!#lists.isEmpty(expenses)}" class="expenses-table-wrapper">
+            <table class="expenses-table">
+                <thead>
+                <tr>
+                    <th>Description</th>
+                    <th>Category</th>
+                    <th>Merchant</th>
+                    <th>Amount</th>
+                    <th>Date</th>
+                    <th>Actions</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="expense : ${expenses}"
+                    th:attr="data-href=@{/expenses/{id}(id=${expense.id})}, data-expense-name=${expense.description != null ? expense.description : 'Expense #' + expense.id}">
+                    <td th:text="${expense.description != null ? expense.description : '—'}">Coffee</td>
+                    <td th:text="${expense.category != null ? expense.category : '—'}">Food</td>
+                    <td th:text="${expense.merchant != null ? expense.merchant : '—'}">Local Cafe</td>
+                    <td th:text="${expense.amount != null ? '$' + #numbers.formatDecimal(expense.amount, 1, 'COMMA', 2, 'POINT') : '—'}">
+                        $4.50
+                    </td>
+                    <td th:text="${expense.timestamp != null ? #temporals.format(expense.timestamp, 'MMM d, yyyy HH:mm') : '—'}">
+                        Mar 10, 2024 09:15
+                    </td>
+                    <td class="actions">
+                        <a th:href="@{/expenses/{id}/edit(id=${expense.id})}" class="btn btn-edit">Edit</a>
+                        <form th:action="@{/expenses/{id}/delete(id=${expense.id})}"
+                              method="post"
+                              class="inline-form"
+                              onsubmit="return confirm('Are you sure you want to delete this expense? This action cannot be undone.');">
+                            <button type="submit" class="btn btn-delete">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+</main>
+
+<div th:insert="~{fragments/footer :: footer}"></div>
+<script th:src="@{/js/expenses.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,6 +1,17 @@
-<header th:fragment="header" class="site-header">
+<header th:fragment="header" class="site-header" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
     <link rel="stylesheet" th:href="@{/css/header.css}">
-    <nav>
-        <a th:href="@{/}">Home</a>
-    </nav>
+    <div class="header-inner">
+        <a th:href="@{/}" class="brand">Glitterfin</a>
+        <nav class="primary-nav">
+            <a th:href="@{/}">Home</a>
+            <a th:href="@{/expenses}">Expenses</a>
+        </nav>
+        <div class="auth-controls">
+            <a sec:authorize="isAnonymous()" th:href="@{/login}" class="login-link">Login</a>
+            <form sec:authorize="isAuthenticated()" th:action="@{/logout}" method="post" class="logout-form">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                <button type="submit" class="logout-button">Logout</button>
+            </form>
+        </div>
+    </div>
 </header>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,19 +1,39 @@
 <!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
 <head>
-    <title>Spring Security Example </title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign in • Glitterfin</title>
+    <link rel="stylesheet" th:href="@{/css/login.css}">
 </head>
-<body>
-<div th:if="${param.error}">
-    Invalid username and password.
-</div>
-<div th:if="${param.logout}">
-    You have been logged out.
-</div>
-<form th:action="@{/login}" method="post">
-    <div><label> User Name : <input type="text" name="username"/> </label></div>
-    <div><label> Password: <input type="password" name="password"/> </label></div>
-    <div><input type="submit" value="Sign In"/></div>
-</form>
+<body class="auth-body">
+<div th:insert="~{fragments/header :: header}"></div>
+
+<main class="auth-main">
+    <section class="auth-card" role="main">
+        <h1 class="auth-title">Welcome back</h1>
+        <p class="auth-subtitle">Sign in to manage your Glitterfin expenses.</p>
+
+        <div th:if="${param.error}" class="auth-alert auth-alert--error" role="alert">
+            Invalid username or password. Please try again.
+        </div>
+        <div th:if="${param.logout}" class="auth-alert auth-alert--success" role="status">
+            You have been logged out successfully.
+        </div>
+
+        <form th:action="@{/login}" method="post" class="auth-form">
+            <div class="form-field">
+                <label for="username">Email</label>
+                <input id="username" name="username" type="text" autocomplete="username" required
+                       th:value="${param.username}">
+            </div>
+            <div class="form-field">
+                <label for="password">Password</label>
+                <input id="password" name="password" type="password" autocomplete="current-password" required>
+            </div>
+            <button type="submit" class="auth-submit">Sign in</button>
+        </form>
+    </section>
+</main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rely on Spring Security to gate expense list and mutation endpoints instead of manual checks in the controller
- simplify the expenses template by removing unused authentication messaging and showing content based on the expense list only
- show the shared footer only after the main content so it appears at the bottom of the page instead of overlaying the viewport

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca2a5f68148328b790e2864840b0cc